### PR TITLE
Fix initialization method to keep zipper's rigthPart in reversed order

### DIFF
--- a/_posts/list-zipper-swift/2019-05-24-list-zipper-swift.md
+++ b/_posts/list-zipper-swift/2019-05-24-list-zipper-swift.md
@@ -69,7 +69,7 @@ and the remaining part of the list.
 ```swift
   init(from list: [T] = []) {
     cursor = list.first
-    rightList = list
+    rightList = list.reversed()
   }
 
   /// Convert to a swift array


### PR DESCRIPTION
Zipper's right part should be reversed since initialization. 
Otherwise, when we convert back using `toList()`, right part will have backward order as we reverse it:
```swift
  func toList() -> [T] {
// ...
      return leftList + rightList.reversed()
  }
```