### PR TITLE
Fix typos and grammar across all blog posts

### DIFF
--- a/_posts/an-alternative-error-handling-strategy-cpp/2013-08-27-an-alternative-error-handling-strategy-cpp.md
+++ b/_posts/an-alternative-error-handling-strategy-cpp/2013-08-27-an-alternative-error-handling-strategy-cpp.md
@@ -2,8 +2,8 @@
 layout: post
 title: An alternative error handling strategy for C++
 description: We treat three historical ways to handle errors,
-  and consider a functional approach using monades to handle error in C++.
-  We provide a C++ implementation unsing templates and discuss the pros and cons.
+  and consider a functional approach using monads to handle errors in C++.
+  We provide a C++ implementation using templates and discuss the pros and cons.
 author: Jérémy Cochoy
 date: 2013-08-27 + 0100
 categories: programming C++ monads language software script
@@ -16,7 +16,7 @@ redirect_from:
 ## Error handling
 
 This not so short post is dedicated to a subject that may interest many
-programers: error handling.
+programmers: error handling.
 
 Error handling is the "dark side" of programming. It is both the heart of
 real world applications, and the dirty stuff you would like to avoid.
@@ -27,8 +27,8 @@ Since the C years, I know three most common ways of handling errors.
 
 'C-Style' handling is the easiest way to do it, but it isn't completely satisfying.
 
-C-Style error handling is basicaly "returning an error code when the application
-failed". Here is short example.
+C-Style error handling is basically "returning an error code when the application
+failed". Here is a short example.
 
 ``` cpp
 int find_slash(const char *str)
@@ -55,29 +55,29 @@ if (find_slash(string) == -1)
 
 ### What's good here?
 
-You can (and actualy, in C style, you do), right after the call, directly handle
-the error by eventualy displaying a message and terminating the application,
+You can (and actually, in C style, you do), right after the call, directly handle
+the error by eventually displaying a message and terminating the application,
 or just retrieving the last state, aborting the computation...
 
-When you wan't to find where the error handling is made, you just have to look at
+When you want to find where the error handling is made, you just have to look at
 the __function call__. It's __right__ after.
 
 ### What's bad here?
 
-As some may have told you, it mix error handling with proper "execution flow".
-When you read linearly the code as the code execute, you read sometime error
-handling, and some time program logic. That's really bad, because you would like to
+As some may have told you, it mixes error handling with proper "execution flow".
+When you read linearly the code as the code executes, you read sometimes error
+handling, and sometimes program logic. That's really bad, because you would like to
 read either "program logic" or "error handling".
 
 Also notice that you are limited to an "error code". If you want to provide
-more informations, you'll have to create some functions (like errstr) and / or
-use global variables;
+more information, you'll have to create some functions (like errstr) and / or
+use global variables.
 
 ## Do it C++-style: exceptions
 
 When C was "enhanced" to c++, a new way of handling errors was introduced. It
 was "exceptions". Exceptions are a way of breaking the normal flow of your code
-by "throwing" an error that will be "catched" somewhere else. Again, a short example.
+by "throwing" an error that will be "caught" somewhere else. Again, a short example.
 
 ``` cpp
 int find_slash(const char *str)
@@ -110,41 +110,41 @@ catch(AnException& e)
 ### What's good here?
 
 Program logic and error handling are separated. On one side you can see how the function
-whork and when it fail, on the other part you can see what it does if it failed.
-It's pretty, simplify reading of both error handling and program logic.
+works and when it fails, on the other part you can see what it does if it failed.
+It's pretty, simplifies reading of both error handling and program logic.
 
 The second point is that now you can give as many information as you like, since
 you can put what you want in your MyException object.
 
 ## What's bad here?
 
-Writing exceptions well is verbose. You need an exception tree, if possible not too big, so that you can catch only the exception you are interesting it. Also, you need some
-error codes inside, to know exactly what hapenned, retrieve an error message, etc.
+Writing exceptions well is verbose. You need an exception tree, if possible not too big, so that you can catch only the exception you are interested in. Also, you need some
+error codes inside, to know exactly what happened, retrieve an error message, etc.
 Writing exceptions class __is__ verbose, it's the cost of the flexibility given by the
-ability to handle more informations embeded as an error.
+ability to handle more information embedded as an error.
 
 The way encouraged by this philosophy is to postpone error handling as late as possible,
-so that users can have the highest flexibility to handle errors. Thats theoricaly a good
+so that users can have the highest flexibility to handle errors. That's theoretically a good
 thing, but…
 
-In big applications, you __can't__ find esily where the error is handled. When you wan't
+In big applications, you __can't__ find easily where the error is handled. When you want
 to know what would be the path of an error, you have to jump across files, functions,
 and it's really hard to find, if you introduce a new exception deep in the "call ~graph~ tree" (I mean the graph you would have if you draw each function call) then you have to
 figure out where it should be handled, if it is already handled, in which places. It's
-really hard when the application is big, old, not really well writen everywhere. Actualy
+really hard when the application is big, old, not really well written everywhere. Actually
 it's the case of most of the commercial projects. And that is that.
 
-That's what make me state "Exceptions are dangerous". Of course, they provide a pretty
-well to handle error… but only when you are working on small project, where the
+That's what makes me state "Exceptions are dangerous". Of course, they provide a pretty
+good way to handle errors… but only when you are working on small project, where the
 "call graph" is simple and easy to get in the mind.
 
 ## The error box pattern
 
-I call it a pattern, so that people don't be afraid. At the end, I'll call it with it's
+I call it a pattern, so that people don't get afraid. At the end, I'll call it with its
 right name, so please, be patient.
 
 The main idea is creating a box that can contain either an error message or a value. We
-will limit ourself to a string, and nothing more, because it's actualy not so easy to
+will limit ourselves to a string, and nothing more, because it's actually not so easy to
 implement. We will try to keep the syntax readable, understandable, for use cases.
 We won't handle correctly copy constructor, more than one parameter functions,
 and rvalues. We will keep it as simple as possible.
@@ -196,8 +196,8 @@ if(!v)
 }
 ```
 
-Ok, so what happened ? Bind is a member function that takes your function, and tries
-to apply it. If there is a value in the "error box", then it aplies to function, and then
+Ok, so what happened? Bind is a member function that takes your function, and tries
+to apply it. If there is a value in the "error box", then it applies the function, and then
 returns an error box (the compiler won't let you give a function that doesn't return
 an error box).
 
@@ -209,20 +209,20 @@ functions of type `E<something_out> f(E<something_in>)`.
 ### What's good here?
 
 Once again, program logic (the chain) and error handling (the if) are separated. Like
-with exception, we have the ability to read the chain and don't think about where
-the execution is interrupted. Actualy, the chain __may__ be interrupted at __any__ step.
+with exceptions, we have the ability to read the chain and don't think about where
+the execution is interrupted. Actually, the chain __may__ be interrupted at __any__ step.
 But we can think as if no error is happening and check quickly if our logic is right.
 
 Of course, typing will prevent you from binding format after a display, so we
 don't lose any typing capabilities.
 
 Notice that we aren't calling any of those function in any other. We are "composing"
-them at the end. That is the key to make it works. You should, write small modular
+them at the end. That is the key to make it work. You should write small modular
 functions (hey, look at that: you __should__ write generic code so that it can work)
-that accept a value, then compute an other "new" value, or fail. And at each
+that accept a value, then compute another "new" value, or fail. And at each
 step, you don't have to think about where an exception may interrupt your control
-flow and take care of maintain you stuff in a valid state (exception safety is basically
-beeing always looking at each call you do, and figure out if the function can interrupt
+flow and take care of maintaining your stuff in a valid state (exception safety is basically
+being always looking at each call you do, and figuring out if the function can interrupt
 your flow and what will happen if it does). For this point, it's "safer".
 
 As with exceptions, we can have "as many information as you like", although in this
@@ -240,18 +240,18 @@ Big projects are more "linear" and easy to read.
 First, it's new. It's not integrated to C++, it's not the standard way, and with the
 stl you'll still have to use exceptions.
 
-It's still a bit too much verbose for my taste. The need to write explicitely the type in
+It's still a bit too verbose for my taste. The need to write explicitly the type in
 `fail<int>("...")` is bad. If you had a polymorphic error type, then it's worst because
 you'll have to write `fail<return_type, error_type>("...")`.
 
-It do not provide an easy way to call a function that need more than one argument.
+It does not provide an easy way to call a function that needs more than one argument.
 In some other languages, you have "applicative" types and currification that solve it
 nicely, but that's far from what you may expect from c++. I'm more likely to think that
 a `bind2(E<a>, E<b>, f)` and `bind3(E<a>, E<b>, E<c>, f)` function could be used.
 Variadic templates may help.
 
 To get the value "out of the box", we have to check if the box is really a value,
-and then call a "to_value" method. And we have no means from doing it without
+and then call a "to_value" method. And we have no way of doing it without
 checking. What we would like to have is "deconstruction" of objects, but this doesn't
 exist in c++, and it's not the kind of things you just have to say "hey, let's
 add it to the next standard".
@@ -272,7 +272,7 @@ A bit stranger, lists are monad. They are "a value" in a context, from a certain
 point of view.
 
 Let's start by implementing the E class you saw above. I'm relying on C++11 `decltype`
-and `auto -> decltype` wich allow figuring out the type of things from expressions. It's
+and `auto -> decltype` which allow figuring out the type of things from expressions. It's
 really useful.
 
 The bind function is a bit strange, but it does what I stated previously.
@@ -460,7 +460,7 @@ public:
 };
 ```
 
-Oh, we don't spoke about `ret` and `fail`. Actually, they are just wraper around
+Oh, we didn't speak about `ret` and `fail`. Actually, they are just wrappers around
 the `xxx::fail` and `xxx::ret` functions.
 
 ``` cpp
@@ -483,7 +483,7 @@ E<T> fail(std::string err)
 }
 ```
 
-There, we are, you can compile and play with the example above.
+There we are, you can compile and play with the example above.
 
 If you want more stuff to play with, I also have this "more realistic" example:
 
@@ -509,8 +509,8 @@ typedef std::string str;
 //Parse a +- formated string.
 //If a letter is prefixed by +, then the function toupper is applied.
 //''                                              tolower is applied.
-//Non alphabetical (+ and - excepted) aren't alowed.
-//Words are cut on each space ' '. Other blank characters aren't alowed.
+//Non alphabetical (+ and - excepted) aren't allowed.
+//Words are cut on each space ' '. Other blank characters aren't allowed.
 E<vs> parse(std::string str)
 {
     int mode = 0;
@@ -559,7 +559,7 @@ E<vs> parse(std::string str)
     return ret(vec);
 }
 
-//Take the first word and append it to the begining of all other words.
+//Take the first word and append it to the beginning of all other words.
 //Vec should contain at least one element.
 E<vs> prefixy(vs vec)
 {

--- a/_posts/arduino-archlinux/2013-03-31-arduino-arclinux-en.md
+++ b/_posts/arduino-archlinux/2013-03-31-arduino-arclinux-en.md
@@ -2,7 +2,7 @@
 layout: post
 title: Arduino Uno with ArchLinux (3.8.4-1-ARCH)
 description: Explain how to bypass a bug with 2013 arclinux version
-  of the arduino developping environment.
+  of the arduino developing environment.
 author: Jérémy Cochoy
 date: 2013-03-31 + 0100
 categories: arduino software arclinux linux
@@ -11,11 +11,11 @@ redirect_from:
   - /blog/arduino-archlinux/en.html
 ...
 
-I quickly explain how to make your arduino card works with your ArchLinux distrib by patching and installing the last version of rxtx.
+I quickly explain how to make your arduino card work with your ArchLinux distrib by patching and installing the latest version of rxtx.
 
 ## Step 1 : Arduino package
 
-Install the aur arduino package using the well known and loved binnary : yaourt.
+Install the aur arduino package using the well known and loved binary: yaourt.
 
 ``` shell
 yaourt -S arduino
@@ -68,11 +68,11 @@ make && sudo make install
 
 ## Use your arduino
 
-You can now launch the arduino IDE (command arduino) and upload a test sketch (like blink). You can select your arduino uno wich will probably show as "ttyACM0" in the device list.
+You can now launch the arduino IDE (command arduino) and upload a test sketch (like blink). You can select your arduino uno which will probably show as "ttyACM0" in the device list.
 
-## Some informations
+## Some information
 
-We disable the flag `--diseable-lockfile` so that errors messages diseapear speaking about the impossibility to write lock files. We also added the right .h file containing `UTS_RELEASE` to remove stupid compiling errors (the file in wich the macro is defined changed recently). To finish, we had to modify rxtx's code (read the comments, they ask you to add missing devices) so that you can use ttyACMx. An other solution would be to add a symbolic link in /dev/ from a ttyUSBx to a ttyACMx.
+We disable the flag `--disable-lockfile` so that error messages disappear speaking about the impossibility to write lock files. We also added the right .h file containing `UTS_RELEASE` to remove stupid compiling errors (the file in which the macro is defined changed recently). To finish, we had to modify rxtx's code (read the comments, they ask you to add missing devices) so that you can use ttyACMx. Another solution would be to add a symbolic link in /dev/ from a ttyUSBx to a ttyACMx.
 
 Anyway, if you can't use your arduino, and you have an error of the style `processing.app.SerialNotFoundException: [..] « /dev/ttyACM0 » not found`, it's probably that ttyACM is not in the list of rxtx's devices.
 

--- a/_posts/arduino-archlinux/2013-03-31-arduino-arclinux-fr.md
+++ b/_posts/arduino-archlinux/2013-03-31-arduino-arclinux-fr.md
@@ -2,7 +2,7 @@
 layout: post
 title: Arduino Uno sous ArchLinux (3.8.4-1-ARCH)
 description: Explique comment contourner un bug avec la version
-  2013 de l'environement de développement arduino sous arclinux.
+  2013 de l'environnement de développement arduino sous arclinux.
 author: Jérémy Cochoy
 date: 2013-03-31 + 0100
 categories: arduino software arclinux linux
@@ -11,9 +11,9 @@ redirect_from:
   - /blog/arduino-archlinux/fr.html
 ...
 
-Voilà que je ressort mon arduino de mes cartons, motivé à dépoussiérer le code de ma 'boite musicale'. Et quel ne fut pas ma surprise quand le package rxtx refusa de s'installer suite a des erreurs de compilation.
+Voilà que je ressors mon arduino de mes cartons, motivé à dépoussiérer le code de ma 'boite musicale'. Et quelle ne fut pas ma surprise quand le package rxtx refusa de s'installer suite à des erreurs de compilation.
 
-Vous commencez sûrement à me connaître ; je n'ai pas abandonné pour si peu. Voilà donc que je me retrouve a publier ce petit billet, accompagné des instructions pour patcher et installer la dernière version de rxtx sous votre système :)
+Vous commencez sûrement à me connaître ; je n'ai pas abandonné pour si peu. Voilà donc que je me retrouve à publier ce petit billet, accompagné des instructions pour patcher et installer la dernière version de rxtx sous votre système :)
 
 
 ## Étape 1 : Arduino package
@@ -27,7 +27,7 @@ yaourt -S arduino
 Étape 2 : Télécharger, patcher et installer rxtx
 ================================================
 
-Telechargez la pre-release depuis http://rxtx.qbang.org/wiki/index.php/Download :
+Téléchargez la pre-release depuis http://rxtx.qbang.org/wiki/index.php/Download :
 
 ``` shell
 wget http://rxtx.qbang.org/pub/rxtx/rxtx-2.2pre2.zip
@@ -42,13 +42,13 @@ Lancez configure avec l'option --disable-lockfile :
 ```
 
 
-Ici, si vous tentez de compiler, vous aurez probablement une erreur `UTS_RELEASE` est indéfini. Pour corriger ce problème, commencez par trouver le fichier utsrelease.h (`find /usr/ -name 'utsrelease.h'`). Pour ma part, il se trouvait dans `/lib/modules/3.8.4-1-ARCH/build/include/generated/`. Ensuite, incluez le dans config.h(C'est un fichier généré par configure), de facon à ce que la constant soit définie partout.
+Ici, si vous tentez de compiler, vous aurez probablement une erreur `UTS_RELEASE` est indéfini. Pour corriger ce problème, commencez par trouver le fichier utsrelease.h (`find /usr/ -name 'utsrelease.h'`). Pour ma part, il se trouvait dans `/lib/modules/3.8.4-1-ARCH/build/include/generated/`. Ensuite, incluez-le dans config.h (c'est un fichier généré par configure), de façon à ce que la constante soit définie partout.
 
 ``` shell
 echo "\n#include \"/lib/modules/3.8.4-1-ARCH/build/include/generated/utsrelease.h\"\n" > config.h
 ```
 
-Maintenant, on doit ajouter ttyACM à la liste des périphériques. On modifit le fichier src/gnu/io/RXTXCommDriver.java en ajoutant une entrée à un tableau (ttyACM). Regardez le fichier diff suivant :
+Maintenant, on doit ajouter ttyACM à la liste des périphériques. On modifie le fichier src/gnu/io/RXTXCommDriver.java en ajoutant une entrée à un tableau (ttyACM). Regardez le fichier diff suivant :
 
 
 ``` shell
@@ -75,13 +75,13 @@ make && sudo make install
 
 ## Utilisez votre arduino
 
-Vous pouvez maintenant lancer l'IDE arduino (commande arduino) et charger un programme de test. Vous pouvez sélectionner votre carte dans la liste des périphérique, probablement sous le nom "ttyACM0".
+Vous pouvez maintenant lancer l'IDE arduino (commande arduino) et charger un programme de test. Vous pouvez sélectionner votre carte dans la liste des périphériques, probablement sous le nom "ttyACM0".
 
 ## Quelques infos
 
-On désactive l'option `--diseable-lockfile` pour faire disparaître des messages d'erreur parlant d'impossibilité d'écrire les fichiers de lock. On ajouter le bon fichier .h contenant `UTS_RELEASE` pour éviter de stupide erreur de compilation (le fichier dans le quel est définit la macro a changé récemment). Enfin, il est nécessaire de modifier le code de rxtx (lisez les commentaires, vous verez qu'on vous demande explicitement de rajouter les devices manquant, en vous proposant la liste de tous ceux possible, et elle est bien longue!) pour que vous puissiez utiliser ttyACMx. Une autre solution serait d'ajouter un lien symbolique dans /dev/ d'un ttyUSBx vers un ttyACMx, par exemple (ttyUSB figure dans le tableau où nous avons ajouter ttyACM).
+On désactive l'option `--disable-lockfile` pour faire disparaître des messages d'erreur parlant d'impossibilité d'écrire les fichiers de lock. On ajoute le bon fichier .h contenant `UTS_RELEASE` pour éviter de stupides erreurs de compilation (le fichier dans lequel est définie la macro a changé récemment). Enfin, il est nécessaire de modifier le code de rxtx (lisez les commentaires, vous verrez qu'on vous demande explicitement de rajouter les devices manquants, en vous proposant la liste de tous ceux possibles, et elle est bien longue!) pour que vous puissiez utiliser ttyACMx. Une autre solution serait d'ajouter un lien symbolique dans /dev/ d'un ttyUSBx vers un ttyACMx, par exemple (ttyUSB figure dans le tableau où nous avons ajouté ttyACM).
 
-Bref, en fin de compte, si vous ne parvenez pas à utiliser votre arduino et que vous avez une erreur du type `processing.app.SerialNotFoundException: Port série « /dev/ttyACM0 » non trouvé`, c'est peut-etre tout simplement que ttyACM ne figure pas dans les périphériques accepté par rxtx.
+Bref, en fin de compte, si vous ne parvenez pas à utiliser votre arduino et que vous avez une erreur du type `processing.app.SerialNotFoundException: Port série « /dev/ttyACM0 » non trouvé`, c'est peut-être tout simplement que ttyACM ne figure pas dans les périphériques acceptés par rxtx.
 
 ## Références :
  *  <http://arduino.cc/en/Guide/troubleshooting#toc1> Drivers / Linux.

--- a/_posts/arduino-as-icsp/2012-05-25-arduino-as-icsp.md
+++ b/_posts/arduino-as-icsp/2012-05-25-arduino-as-icsp.md
@@ -2,7 +2,7 @@
 layout: post
 title: Arduino as ICSP - Programmeur pour microcontrôleurs atmel
 description: Comment transformer son arduino en un programmeur pour
-  microcontroleurs Atmel. Cela permet notament de charger le boot
+  microcontroleurs Atmel. Cela permet notamment de charger le boot
   loader arduino sur de nouveaux ATMegas.
 author: Jérémy Cochoy
 date: 2012-05-25 +0100
@@ -12,54 +12,54 @@ lang: fr
 
 ## ICSP?
 
-ICSP (In-Circuit Serial Programming) ou encore ISP est le nom donné à l’interface de programmation des microcontroleurs pouvant être reprogrammé _in situ_. C'est le cas des AVR de chez Atmels, dont figure la très célèbre famille des Atméga (Atmega328P pour la carte arduino uno), mais aussi les petits ATtiny, qui n'ont que peux à envier aux atméga, puisque pouvant surpasser la cadence des seconds (20Mhz pour l'attiny84 et l'attiny85).
+ICSP (In-Circuit Serial Programming) ou encore ISP est le nom donné à l’interface de programmation des microcontroleurs pouvant être reprogrammés _in situ_. C’est le cas des AVR de chez Atmel, dont figure la très célèbre famille des Atméga (Atmega328P pour la carte arduino uno), mais aussi les petits ATtiny, qui n’ont que peu à envier aux atméga, puisque pouvant surpasser la cadence des seconds (20Mhz pour l’attiny84 et l’attiny85).
 
-Si vous disposez d'une carte arduino, vous ne programmez pas votre microcontroleur grace à l'ICSP, mais via le bootloader arduino qui a chaque démarrage (appuis sur reset si vous préférez, ou mise sous tension) attend quelques instant une éventuelle communication sur les pins 0 et 1 (RX et TX) avant de finalement lancer votre programme (aussi appelé sketch). Vous l'aurez comprit, la programmation d'une arduino se fait en effectuant un reset et en transmettant les données sous la forme d'une [liaison série asynchrone][uart].
+Si vous disposez d'une carte arduino, vous ne programmez pas votre microcontroleur grâce à l'ICSP, mais via le bootloader arduino qui à chaque démarrage (appui sur reset si vous préférez, ou mise sous tension) attend quelques instants une éventuelle communication sur les pins 0 et 1 (RX et TX) avant de finalement lancer votre programme (aussi appelé sketch). Vous l'aurez compris, la programmation d'une arduino se fait en effectuant un reset et en transmettant les données sous la forme d'une [liaison série asynchrone][uart].
 
-L'inconvénient de cette méthode, est qu'un microcontroleur "brute de fonderie" ne permet pas une telle chose (C'est le cas quand vous achetez directement des PIC, PICAXE ou ATMegas au constructeur) et qu'il faut donc charger le bootloader arduino.
+L'inconvénient de cette méthode est qu'un microcontroleur "brut de fonderie" ne permet pas une telle chose (c'est le cas quand vous achetez directement des PIC, PICAXE ou ATMegas au constructeur) et qu'il faut donc charger le bootloader arduino.
 
-Une autre raison, plus pragmatique, est que le bootloader arduino mange tout de même plus d'une page mémoire, et que pour certaines applications -- une aventure qui ne m'est pour le moment pas arrivé -- il peut être utile de gagner quelques précieux octets.
+Une autre raison, plus pragmatique, est que le bootloader arduino mange tout de même plus d'une page mémoire, et que pour certaines applications -- une aventure qui ne m'est pour le moment pas arrivée -- il peut être utile de gagner quelques précieux octets.
 
-La programmation atmel se fait via une interface SPI pour [Serial Peripherical Interface][serial-peripherical-interface] (c'est à ce moment que l'ordre des lettres d'un acronyme devien crucial pour ne pas se retrouver confus).
+La programmation atmel se fait via une interface SPI pour [Serial Peripheral Interface][serial-peripherical-interface] (c'est à ce moment que l'ordre des lettres d'un acronyme devient crucial pour ne pas se retrouver confus).
 
 ### Arduino as ISP
 
-Par chance, des gens bien veillant se sont sacrifié pour implémenter un programmateur ISP à travers la carte arduino. Concrètement, l'utilisation du sketch Arduino As ISP (disponible dans la rubrique 'exemples' de l'IDE arduino) permet de transformer la carte arduino en un programmateur ISP, dialoguant avec le PC d'une façon _standard_ -- compenez que les utilitaires pour avr comme avrdude arrivent a communiquer avec l'arduino -- et pouvant pogrammez un microcontroleur atmel... si vous avez de la chance.
+Par chance, des gens bienveillants se sont sacrifiés pour implémenter un programmateur ISP à travers la carte arduino. Concrètement, l'utilisation du sketch Arduino As ISP (disponible dans la rubrique 'exemples' de l'IDE arduino) permet de transformer la carte arduino en un programmateur ISP, dialoguant avec le PC d'une façon _standard_ -- comprenez que les utilitaires pour avr comme avrdude arrivent à communiquer avec l'arduino -- et pouvant programmer un microcontroleur atmel... si vous avez de la chance.
 
 Retenez qu'un programmateur ISP d'atmels doit avoir le contrôle sur 4 pins du composant : Le pin reset, car le protocole de programmation demande de pouvoir faire des _choses bizarres_ avec ce dernier, et les 3 pins SPI (MISO, MOSI et SCLK. On n'utilise pas le SS). Le cablage de votre arduino avec un atmega est décrit :
 
-- Dans le code de l'Arduino As ISP; les pins utilisé par le sketch sont indiqué.
+- Dans le code de l'Arduino As ISP; les pins utilisés par le sketch sont indiqués.
   Y figure aussi au port 9 un "heartbeat" qui permet de savoir quand votre sketch
-  a planté -- ce qui arrive plus souvent qu'on le souhaiterais.
-- Su le [site officiel arduino][arduino-to-breadboard], dont l'image suivante est tirée.
+  a planté -- ce qui arrive plus souvent qu'on le souhaiterait.
+- Sur le [site officiel arduino][arduino-to-breadboard], dont l'image suivante est tirée.
 
-Voici donc le schéma d'un montage avec votre arduino comportant le sketh Arduino As ISP, pour programmer un atmega328p (Si vous voulez programmer un autre atmel, il suffit de rechercher les port MOSI, MISO, SCLK et reset, puis de cabler comme sur l'atmega328p).
+Voici donc le schéma d'un montage avec votre arduino comportant le sketch Arduino As ISP, pour programmer un atmega328p (si vous voulez programmer un autre atmel, il suffit de rechercher les ports MOSI, MISO, SCLK et reset, puis de câbler comme sur l'atmega328p).
 
 ![Montage arduino](data/BreadboardAVR.png)
 
-Sachez que, pour ma part, j'ai du modifier le sketch d'Arduino As ISP, en changeant le baud-rate de la liaison série (avec le PC) à 9600 (par défaut 12900), pour que tout se passe bien. (La pemiere ligne de setup() :   Serial.begin(19200); )
+Sachez que, pour ma part, j'ai dû modifier le sketch d'Arduino As ISP, en changeant le baud-rate de la liaison série (avec le PC) à 9600 (par défaut 19200), pour que tout se passe bien. (La première ligne de setup() :   Serial.begin(19200); )
 
-### Hologe?
+### Horloge?
 
-Si la résistance de pull-up sur le reset n'est pas obligatoire, pour un microcontroleur sortie de l'usine, il se peut que vous aillez besoin d'une horloge externe. L'horloge externe ou interne se configure via les fuses (fusibles), des registres spéciaux que le peut modifier... via ICSP -- donc, une fois que vous aurez réussi à faire fonctionner tout ce beau monde, ce qui ne nous aide pas.
+Si la résistance de pull-up sur le reset n'est pas obligatoire, pour un microcontroleur sorti de l'usine, il se peut que vous ayez besoin d'une horloge externe. L'horloge externe ou interne se configure via les fuses (fusibles), des registres spéciaux que l'on peut modifier... via ICSP -- donc, une fois que vous aurez réussi à faire fonctionner tout ce beau monde, ce qui ne nous aide pas.
 
-Pour ma part, j'ai été obligé d'ajouter une horloge externe pour avoir une réponse du microcontroleur lorsqu’on lui demande d'épeler son nom (signature du composant). Un simple crystal 16MHz avec deux condensateurs 22pF -- non, ça ne marche pas avec 22nF, ce n'est pas faute d'avoir essayé... -- feras l'affaire. Il est fort probable qu'un crystal à 8MHz convienne aussi -- avec les mêmes condensateurs.
+Pour ma part, j’ai été obligé d’ajouter une horloge externe pour avoir une réponse du microcontroleur lorsqu’on lui demande d’épeler son nom (signature du composant). Un simple crystal 16MHz avec deux condensateurs 22pF -- non, ça ne marche pas avec 22nF, ce n’est pas faute d’avoir essayé... -- fera l’affaire. Il est fort probable qu’un crystal à 8MHz convienne aussi -- avec les mêmes condensateurs.
 
 ### Let's GO!
 
-Votre sketch est sur votre arduino, votre circuit est opérationnel, vous avez vérifier chaque câble, chaque branchement, et relut le schéma 8 fois? Bien, alors revérifiez encore une fois dans le doute.
+Votre sketch est sur votre arduino, votre circuit est opérationnel, vous avez vérifié chaque câble, chaque branchement, et relu le schéma 8 fois? Bien, alors revérifiez encore une fois dans le doute.
 
-Installez la suite AVRtools (WinAVR pour windows, votre gestionnaire de packets sous linux, et pour les autres, à vous de vous débrouiller :D ). Ne pas hésiter à consulter la [documentation de AVRtools][avr-tools].
+Installez la suite AVRtools (WinAVR pour windows, votre gestionnaire de paquets sous linux, et pour les autres, à vous de vous débrouiller :D ). Ne pas hésiter à consulter la [documentation de AVRtools][avr-tools].
 
 Lancez avrdude, avec une commande de cette forme :
 ```shell
 avrdude -p atmega328p -c avrisp -P com4 -b 9600
 ```
-Où vous remplacez atmega328p par votre microcontroleur, et com4 par votre port. Pensez aussi a entrer le baud-rate (-b) figurant dans le code du sketch Arduino As ISP. Si tout vas bien (Vous devez obtenir une réponse de votre microcontroleur, et les noms attendu et reçu doivent correspondre), vous pouvez alors envoyer un sketch avec :
+Où vous remplacez atmega328p par votre microcontroleur, et com4 par votre port. Pensez aussi à entrer le baud-rate (-b) figurant dans le code du sketch Arduino As ISP. Si tout va bien (vous devez obtenir une réponse de votre microcontroleur, et les noms attendu et reçu doivent correspondre), vous pouvez alors envoyer un sketch avec :
 ```shell
 avrdude -p atmega328p -c avrisp -P com4 -b 9600 -U flash:w:sketch.hex
 ```
-Pour plus de détailles sur avrdude, référez vous à la documentation, ou bien
+Pour plus de détails sur avrdude, référez-vous à la documentation, ou bien
 au site de [LadyAda][avrdude].
 
 Sur ce, amusez vous bien :)

--- a/_posts/boost-property-tree/2015-12-21-boost-property-tree.md
+++ b/_posts/boost-property-tree/2015-12-21-boost-property-tree.md
@@ -11,7 +11,7 @@ redirect_from:
   - /site/blog/posts/boost-property-tree/en.html
 ...
 
-**Property Tree** is a sublibrary of boost that allow you handling _tree of property_. It can be used to represent XML, JSON, INI files, file paths, etc. In our case, we will be interested in loading and writing JSON, to provide an interface with other applications.
+**Property Tree** is a sublibrary of boost that allows you to handle _trees of properties_. It can be used to represent XML, JSON, INI files, file paths, etc. In our case, we will be interested in loading and writing JSON, to provide an interface with other applications.
 
 Our example case will be the following json file :
 
@@ -58,13 +58,13 @@ pt::ptree root;
 pt::read_json("filename.json", root);
 ```
 
-Now, we have a populated property tree thatis waiting from us to look at him. Notice that you can also read from a stream, for example `pt::read_json(std::cin, root)`{.cpp} is also allowed.
+Now, we have a populated property tree that is waiting for us to look at it. Notice that you can also read from a stream, for example `pt::read_json(std::cin, root)`{.cpp} is also allowed.
 
-If your json file is illformed, you will be granted by a `pt::json_parser::json_parser_error`.
+If your json file is ill-formed, you will be greeted by a `pt::json_parser::json_parser_error`.
 
 ### Loading some values
 
-We can access a value from the root by giving it's path to the `get` method.
+We can access a value from the root by giving its path to the `get` method.
 
 ```cpp
 // Read values
@@ -73,15 +73,15 @@ int height = root.get<int>("height", 0);
 std::string msg = root.get<std::string>("some.complex.path");
 ```
 
-If the field your are looking to doesn't exists, the `get()` method will throw a `pt::ptree_bad_path` exception, so that you can recorver from incomplete json files. Notice you can set a default value as second argument, or use `get_optional<T>()` wich return a `boost::optional<T>`.
+If the field you are looking for doesn't exist, the `get()` method will throw a `pt::ptree_bad_path` exception, so that you can recover from incomplete json files. Notice you can set a default value as second argument, or use `get_optional<T>()` which returns a `boost::optional<T>`.
 
-Notice the getter doesn't care about the type of the input in the json file, but only rely on the ability to convert the string to the type you are asking.
+Notice the getter doesn't care about the type of the input in the json file, but only relies on the ability to convert the string to the type you are asking for.
 
 ### Browsing lists
 
 So now, we would like to read a list of objects (in our cases, a list of animals).
 
-We can handle it with a simple for loop, using an iterator. In **c++11**, it become :
+We can handle it with a simple for loop, using an iterator. In **c++11**, it becomes :
 
 ```cpp
 // A vector to allow storing our animals
@@ -100,9 +100,9 @@ for (pt::ptree::value_type &animal : root.get_child("animals"))
 }
 ```
 
-Since `animal.second` is a `ptree`, we can also call call `get()` or `get_child()` in the case our node wasn't just a string.
+Since `animal.second` is a `ptree`, we can also call `get()` or `get_child()` in the case our node wasn't just a string.
 
-A bit more complexe example is given by a list of values. Each element of the list is actualy a `std::pair("", value)` (where value is a `ptree`). It doesnt means that reading it is harder.
+A bit more complex example is given by a list of values. Each element of the list is actually a `std::pair("", value)` (where value is a `ptree`). It doesn't mean that reading it is harder.
 
 ```cpp
 std::vector<std::string> fruits;
@@ -114,11 +114,11 @@ for (pt::ptree::value_type &fruit : root.get_child("fruits"))
 
 ```
 
-In the case the values arent string, we can just call `fruit.second.get_value<T>()` in place of `fruit.second.data()`.
+In the case the values aren't strings, we can just call `fruit.second.get_value<T>()` in place of `fruit.second.data()`.
 
 ### Deeper : matrices
 
-There is nothing now to enable reading of matrices, but it's a good way to check that you anderstood the reading of list. But enought talking, let's have a look at the code.
+There is nothing new to enable reading of matrices, but it's a good way to check that you understood the reading of lists. But enough talking, let's have a look at the code.
 
 ```cpp
 int matrix[3][3];
@@ -139,7 +139,7 @@ You can now read any kind of JSON tree. The next step is being able to read them
 
 ## Writing JSON
 
-Let's say that now, we wan't to produce this tree from our application's data. To do that, all we have to do is build a `ptree` containing our data.
+Let's say that now, we want to produce this tree from our application's data. To do that, all we have to do is build a `ptree` containing our data.
 
 We start with an empty tree :
 ```{.cpp}
@@ -153,7 +153,7 @@ pt::write_json(std::cout, root);
 
 ### Add values
 
-Puting values in a tree can be acomplished with the `put()` method.
+Putting values in a tree can be accomplished with the `put()` method.
 
 ```cpp
 root.put("height", height);
@@ -164,7 +164,7 @@ As you can see, very boring.
 
 ### Add a list of objects
 
-No big deel here, although we now use `add_child()` to put our `animal` node at the root.
+No big deal here, although we now use `add_child()` to put our `animal` node at the root.
 
 ```cpp
 // Create a node
@@ -181,7 +181,7 @@ root.add_child("animals", animals_node);
 Now start the tricky tricks. If you want to add more than one time a node
 named `fish`, you can't call the `put()` method. The call `node.put("name", value)` will
 replace the existing node named `name`. But you can do it by manually pushing your nodes,
-as demonstrated bellow.
+as demonstrated below.
 
 ```cpp
  // Add two objects with the same name
@@ -195,7 +195,7 @@ as demonstrated bellow.
 
 ### Add a list of values
 
-If you remember, list are mades of nodes with empty name. Se we have to build node with empty names, and then use the `push_back()` once again to add all those unnamed childs.
+If you remember, lists are made of nodes with empty names. So we have to build nodes with empty names, and then use the `push_back()` once again to add all those unnamed children.
 
 ```cpp
 // Add a list
@@ -246,4 +246,4 @@ Some links related :
 - [The official documentation](http://www.boost.org/doc/libs/1_60_0/doc/html/property_tree/tutorial.html)
 - [A post on stack overflow](http://stackoverflow.com/questions/2114466/creating-json-arrays-in-boost-using-property-trees)
 
-__Rem__ : At the time of writing, the boost::property_tree library doesn't output typed value. But we can expect that it will be corrected soon.
+__Rem__ : At the time of writing, the boost::property_tree library doesn't output typed values. But we can expect that it will be corrected soon.

--- a/_posts/c++-functional-programming-taste/2013-07-12-c++-functional-programming-taste.md
+++ b/_posts/c++-functional-programming-taste/2013-07-12-c++-functional-programming-taste.md
@@ -1,15 +1,15 @@
 ---
 layout: post
-title: C++ - Un gout de programmation fonctionelle
-description: Une introduction aux nouveux aspect fonctionnel du C++ 11.
-  Il y est question de lambdas, et les applications partielles.
+title: C++ - Un goût de programmation fonctionnelle
+description: Une introduction aux nouveaux aspects fonctionnels du C++ 11.
+  Il y est question de lambdas et d'applications partielles.
 author: Jérémy Cochoy
 date: 2013-07-12 +0100
 categories: c++ programming functional language
 lang: fr
 ...
 
-Dans ce billet, nous allons aborder quelques unes des nouvelles fonctionnalités offerte par le C++11. Elles sont clairement inspiré de la vie dans le monde fonctionnel.
+Dans ce billet, nous allons aborder quelques-unes des nouvelles fonctionnalités offertes par le C++11. Elles sont clairement inspirées de la vie dans le monde fonctionnel.
 
 ## Alpha, Beta, ... Kappa, Lambda!
 
@@ -35,14 +35,14 @@ int b = 42;
 auto f = [&b](int a){return a * b};
 ```
 
-Les lambda permette de faire la même chose de façon plus légère, et ajoute la sémantique de fonction (i.e. on ne peux pas confondre une lambda et un objet en lisant du code, alors qu'on '''pourrait''' avec un foncteur et un objet). Les lambda sont aussi plus proche de d'une fonction anonyme, puisque certaines fonctions (constructeur, opérateur =), implicitement déclaré dans l'exemple ci dessus (on peux faire f = g avec f et g deux AFunctor) n'existent pas (sont explicitement supprimé) pour les lambda.
+Les lambda permettent de faire la même chose de façon plus légère, et ajoutent la sémantique de fonction (i.e. on ne peut pas confondre une lambda et un objet en lisant du code, alors qu'on '''pourrait''' avec un foncteur et un objet). Les lambda sont aussi plus proches d'une fonction anonyme, puisque certaines fonctions (constructeur, opérateur =), implicitement déclarées dans l'exemple ci-dessus (on peut faire f = g avec f et g deux AFunctor) n'existent pas (sont explicitement supprimées) pour les lambda.
 
 
-Par exemple, le constructeur du type d'une lambda (on rappelle qu'en c++11, on peux obtenir le type de `f` avec `decltype(f)`. Par exemple `decltype(3.5f)` ou `std::vector v; decltype(v)`) n'existe pas.
+Par exemple, le constructeur du type d'une lambda (on rappelle qu'en c++11, on peut obtenir le type de `f` avec `decltype(f)`. Par exemple `decltype(3.5f)` ou `std::vector v; decltype(v)`) n'existe pas.
 
 Si f est une lambda, le code `decltype(f) g;` ne compilera pas. Pourtant, si `f` est un `AFunctor`, le code `decltype(f) g;` compilera et correspond à `AFunctor g;`.
 
-Bon, qu'on se rassure, on peux quand même faire une copie d'une lambda :
+Bon, qu'on se rassure, on peut quand même faire une copie d'une lambda :
 ``` cpp
 auto f = [](){return 42};
 
@@ -57,13 +57,13 @@ decltype(f) g4(f);
 
 ## Comment fonctionne une lambda?
 
-En fait, c'est très simple, est tout est décrit sur la page "Lambda" du site "CPPReference".
+En fait, c'est très simple, et tout est décrit sur la page "Lambda" du site "CPPReference".
 
 ``` cpp
 [ capture ] ( params ) mutable exception attribute -> ret { body }
 ```
 
-Dans capture on trouve la façon dont les variables extérieurs à la lambda sont capturé. Il y a deux mode de capture : par valeur, et par référence. Par défaut, [] signifie [=] qui veux dire "tout est récupérer par valeur", et le comportement est identique à une copie des variable(pour les objets comme `std::string`, c'est plutôt un `const std::string&` que vous recevez). On peux aussi spécifier [&] et toute les variables sont récupérées par référence (et peuvent donc être modifiées depuis la lambda). Enfin, pour ceux qui apprécient la finesse, on peux expliciter le comportement pour chacune des variables, par exemple :
+Dans capture on trouve la façon dont les variables extérieures à la lambda sont capturées. Il y a deux modes de capture : par valeur, et par référence. Par défaut, [] signifie [=] qui veut dire "tout est récupéré par valeur", et le comportement est identique à une copie des variables (pour les objets comme `std::string`, c'est plutôt un `const std::string&` que vous recevez). On peut aussi spécifier [&] et toutes les variables sont récupérées par référence (et peuvent donc être modifiées depuis la lambda). Enfin, pour ceux qui apprécient la finesse, on peut expliciter le comportement pour chacune des variables, par exemple :
 ``` cpp
 int a = 42;
 std::vector<int> v;
@@ -84,17 +84,17 @@ auto f5 [&]() {v.push_back(a); a++; msg.push_back('!'); std::cout << msg << std:
 
 La partie "exception" correspond aux spécifications du genre `throw (std::bad_alloc, MyExceptionType)` ou encore `noexcept` (no throw exception safety).
 
-Si vous voulez modifier un objet obtenu par valeur, il vous faudra rajouter "mutable". Cela peux être très utile, si vous voulez appeler des méthodes non const sur une copie d'un objet dans le scope.
+Si vous voulez modifier un objet obtenu par valeur, il vous faudra rajouter "mutable". Cela peut être très utile, si vous voulez appeler des méthodes non const sur une copie d'un objet dans le scope.
 ``` cpp
 std::vector<int> v;
 auto f = [v]() mutable {v.push_back(42); std::cout << v[0] << std::endl;}
 ```
 
-Petite astuce parfois utile : Si une lambda ne capture aucune variable, alors elle peux être convertie en pointeur de fonction.
+Petite astuce parfois utile : si une lambda ne capture aucune variable, alors elle peut être convertie en pointeur de fonction.
 
 ## std::function :
 
-Les std::function représente des fonctions. Ils sont basé sur les templates variadique (l'un des ajout les plus puissant au langage), que l'on peux espérer disponible sous VisualStudio d'ici 2039 (si l'équipe de microsoft ne prend pas de retard). Le constructeur des std::function autorise de les construire avec plus ou moins n'importe quoi (pointeur de fonction, pointeur de fonction membre, lambda, foncteur, ...).
+Les std::function représentent des fonctions. Ils sont basés sur les templates variadiques (l'un des ajouts les plus puissants au langage), que l'on peut espérer disponibles sous VisualStudio d'ici 2039 (si l'équipe de microsoft ne prend pas de retard). Le constructeur des std::function autorise de les construire avec plus ou moins n'importe quoi (pointeur de fonction, pointeur de fonction membre, lambda, foncteur, ...).
 
 En code :
 ``` cpp
@@ -131,7 +131,7 @@ std::function<void(const St&, int)> f = &St::sum;
 
 ## Application partielle.
 
-Tout ça, pour en venir à vous parler de ```std::bind```. Quand on travail avec des langages fonctionnels, on peux appeler une fonction avec seulement une partie de ses arguments. On parle d'_application partielle_. `std::bind` permet de reproduire ce comportement. Prenons une innocente fonction :
+Tout ça, pour en venir à vous parler de ```std::bind```. Quand on travaille avec des langages fonctionnels, on peut appeler une fonction avec seulement une partie de ses arguments. On parle d'_application partielle_. `std::bind` permet de reproduire ce comportement. Prenons une innocente fonction :
 ``` cpp
 void display(int a, int b, int c)
 {
@@ -139,7 +139,7 @@ void display(int a, int b, int c)
 }
 ```
 
-On peux alors construire, grâce à std::bind, différentes spécialisation de cette fonction :
+On peut alors construire, grâce à std::bind, différentes spécialisations de cette fonction :
 ``` cpp
 //On fixe les trois arguments
 std::function<void()> f = std::bind(display, 5, 6, 7);
@@ -148,7 +148,7 @@ f(); // Affiche a : 5 - b : 6 - c : 7
 std::function<void(int)> f = std::bind(display, 5, 6, 7);
 f(42); // Affiche a : 5 - b : 6 - c : 7
 
-//Placeholders::_i désigne le i-ième argument lors de l’appelle de f
+//Placeholders::_i désigne le i-ième argument lors de l’appel de f
 std::function<void(int)> f = std::bind(display, 5, 6, std::placeholders::_1);
 f(42); //  Affiche a : 5 - b : 6 - c : 42
 
@@ -156,17 +156,17 @@ f(42); //  Affiche a : 5 - b : 6 - c : 42
 std::function<void(int, int)> f = std::bind(display, 5, std::placeholders::_1, std::placeholders::_2);
 f(10, 20); //  Affiche a : 5 - b : 10 - c : 20
 
-//On peux changer l'ordre :
+//On peut changer l'ordre :
 std::function<void(int, int)> f = std::bind(display, 5, std::placeholders::_2, std::placeholders::_1);
 f(10, 20); //  Affiche a : 5 - b : 20 - c : 10
 
 ```
 
-Bien entendu, on peux aussi faire des choses plus complexe (passage des arguments par référence avec `std::ref` et `std::cref` dans les arguments de bind, pointeurs de fonction membre, pointeur vers membres, etc.).
+Bien entendu, on peut aussi faire des choses plus complexes (passage des arguments par référence avec `std::ref` et `std::cref` dans les arguments de bind, pointeurs de fonction membre, pointeurs vers membres, etc.).
 
-Si vous vous demandez à quoi ça peux bien servir, et bien dite vous que là où on attend une callback avec une certaine signature (c'est le cas avec beaucoup d'outil de `<algorithm>`) vous avez maintenant la possibilité de spécialiser vos fonctions.
+Si vous vous demandez à quoi ça peut bien servir, eh bien dites-vous que là où on attend une callback avec une certaine signature (c'est le cas avec beaucoup d'outils de `<algorithm>`) vous avez maintenant la possibilité de spécialiser vos fonctions.
 
-Pour ce qui est du coût, il est faible (celons les cas beaucoup de choses peuvent être optimisé lors de la compilation), et n'est un argument recevable que dans certains cas particulier. Donc, à moins de faire du temps réel et de faire ce genre de manipulation dans les parties critique, vous pouvez vous lâcher.
+Pour ce qui est du coût, il est faible (selon les cas beaucoup de choses peuvent être optimisées lors de la compilation), et n'est un argument recevable que dans certains cas particuliers. Donc, à moins de faire du temps réel et de faire ce genre de manipulation dans les parties critiques, vous pouvez vous lâcher.
 
 Voilà, j'espère vous avoir donné un petit aperçu de l'apport du c++11 en matière de manipulation des fonctions.
 

--- a/_posts/cmake-howto/2013-06-30-cmake-howto.md
+++ b/_posts/cmake-howto/2013-06-30-cmake-howto.md
@@ -10,12 +10,12 @@ lang: fr
 
 ## Qu'est-ce que CMake ?
 
-CMake est un utilitaire permettant de générer le "build process" d'un projet. C'est un outils du même genre que les autotools (aussi appelé pour des raisons que je tairai 'autohell') en
+CMake est un utilitaire permettant de générer le "build process" d'un projet. C'est un outil du même genre que les autotools (aussi appelés pour des raisons que je tairai 'autohell') en
 
   * Plus simple à configurer
-  * Plus récent (donc moins de façons de procédé obscures)
+  * Plus récent (donc moins de façons de procéder obscures)
   * Plus performant (dans le sens où, avec cmake, compiler un projet à l'extérieur du repository est extrêmement simple et agréable!)
-  * Vous êtes libre d'organiser vos répertoires/fichier comme vous le désirez.
+  * Vous êtes libre d'organiser vos répertoires/fichiers comme vous le désirez.
 
 Il est bon aussi de savoir que CMake est capable de générer aussi bien des Makefiles que des fichiers de projet VC++ ou XCode (pas mal, hein?).
 
@@ -23,33 +23,33 @@ On a aussi une jolie progression en % de la compilation (et l'on peut toujours u
 
 ##Comment on s'en sert ?
 
-On connais tous le _./autogen.sh_, _./configure_ puis _make && sudo make install_. Bien entendu, on produit tous les fichiers bien salle dans le dossier des sources, ce qui donne une magnifique liste de fichiers à ajouter au .gitignore du votre projet (ou tout autre fichier équivalent pour svn / mercurial). Avec cmake, on peut reproduire le schéma des autotools via `cmake .` puis `make && sudo make install`. Mais mieux, vous pouvez (par exemple) faire `mkdir build && cd build` puis `cmake ..` et `make && sudo make install`. Dite bonjour a la propreté de votre projet grâce à CMake ;)
+On connaît tous le _./autogen.sh_, _./configure_ puis _make && sudo make install_. Bien entendu, on produit tous les fichiers bien sales dans le dossier des sources, ce qui donne une magnifique liste de fichiers à ajouter au .gitignore de votre projet (ou tout autre fichier équivalent pour svn / mercurial). Avec cmake, on peut reproduire le schéma des autotools via `cmake .` puis `make && sudo make install`. Mais mieux, vous pouvez (par exemple) faire `mkdir build && cd build` puis `cmake ..` et `make && sudo make install`. Dites bonjour à la propreté de votre projet grâce à CMake ;)
 
 ##Comment ça fonctionne ?
 
-C'est là qu'est le plus beau. Configurer CMake pour un projet, gérer les dépendances de libs, générer les libs, voir même générer les packages (que ce soit des packages archlinux, debian ...). On prend très vite en main, c'est claire, et la documentation est excellente.
+C'est là qu'est le plus beau. Configurer CMake pour un projet, gérer les dépendances de libs, générer les libs, voire même générer les packages (que ce soit des packages archlinux, debian ...). On prend très vite en main, c'est clair, et la documentation est excellente.
 
-Je ne vais pas détailler comment construire un fichier de config ; le [tutorial CMake](http://www.cmake.org/cmake/help/cmake_tutorial.html) le fait déjà très bien, et l'on trouve tout ce qu'il manque dans le wiki. (Notez que dans un VRAI projet, il vous faudra un peu plus que le tutorial). Je vais aborder les idées générales et les petites astuces qui m'ont servies.
+Je ne vais pas détailler comment construire un fichier de config ; le [tutorial CMake](http://www.cmake.org/cmake/help/cmake_tutorial.html) le fait déjà très bien, et l'on trouve tout ce qu'il manque dans le wiki. (Notez que dans un VRAI projet, il vous faudra un peu plus que le tutorial). Je vais aborder les idées générales et les petites astuces qui m'ont servi.
 
-D'abord, on place les instructions dans un fichier CMakeLists.txt a la racine du projet. On évite donc la multiplication des fichiers de configuration. Il est possible d’appeler des scripts d'autres dossier grâce à `add_subdirectory("${PROJECT_SOURCE_DIR}/your_folder"`). Il est important d'utiliser `${PROJECT_SOURCE_DIR}` pour que tout se place bien quand on souhaite compiler dans un autre dossier.
+D'abord, on place les instructions dans un fichier CMakeLists.txt à la racine du projet. On évite donc la multiplication des fichiers de configuration. Il est possible d’appeler des scripts d’autres dossiers grâce à `add_subdirectory("${PROJECT_SOURCE_DIR}/your_folder"`). Il est important d'utiliser `${PROJECT_SOURCE_DIR}` pour que tout se place bien quand on souhaite compiler dans un autre dossier.
 
-On peut facilement demander a cmake de trouver des libs. En règle générale, on trouve un FindNomDeLaLib.cmake que l'on placera dans projet/cmake/Modules/, et l'on prendras soin d'ajouter `set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")`.
+On peut facilement demander à cmake de trouver des libs. En règle générale, on trouve un FindNomDeLaLib.cmake que l'on placera dans projet/cmake/Modules/, et l'on prendra soin d'ajouter `set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")`.
 
-Une façon pratique pour compiler votre projet est de placer tous vos .c/.cpp dans un dossier src, et de tous les sélectionner (ça évite d'oublier d'ajouter un .cpp a la liste des fichiers du projet). Avec `file(GLOB_RECURSE SOURCE_FILES src/*.cpp SRC)` le liste des fichiers figure dans la variable "SOURCE_FILES". Si il vous faut exclure certains fichiers, vous pouvez utiliser :
+Une façon pratique pour compiler votre projet est de placer tous vos .c/.cpp dans un dossier src, et de tous les sélectionner (ça évite d'oublier d'ajouter un .cpp à la liste des fichiers du projet). Avec `file(GLOB_RECURSE SOURCE_FILES src/*.cpp SRC)` la liste des fichiers figure dans la variable "SOURCE_FILES". S'il vous faut exclure certains fichiers, vous pouvez utiliser :
 `file(GLOB_RECURSE UNWANTED_FILES src/FichierAExclure.cpp SRC)
 list (REMOVE_ITEM SOURCE_FILES ${UNWANTED_FILES})`
 
 Si vous êtes fan des tests unitaires, CMake propose une façon agréable de lancer des tests avec :
-`add_test (NAME NomDuTeste WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/repertoiredexecution" COMMAND "commande a executer")`
-Ça vas de "lancer un programme et vérifier qu'il EXIT_SUCCESS" à "vérifier que la sortie du programme contient cette expression".
+`add_test (NAME NomDuTest WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/repertoiredexecution" COMMAND "commande a executer")`
+Ça va de "lancer un programme et vérifier qu'il EXIT_SUCCESS" à "vérifier que la sortie du programme contient cette expression".
 
-Chose utile, que ne fournissent pas les autotools, c'est une façon unifiée de gèrer le numéro de version de l'application ; Toute les variables d'un CMakeListes peuvent être utiliser pour générer des fichiers à partir de templates (souvent le nom du fichier avec le suffixe .in). En pratique, on définit VERSION_MAJOR et VERSION_MINOR, puis on génère un Version.h, un doxyfile, et on utilise les valeurs pour générer les noms des bibliothèques exportés. C'est simple, intuitif, et très bien expliqué dans le tutoriel. Faire une release se limite alors a changer le numéro de version dans un fichier, et de lancer la compilation pour obtenir les binaires et packages.
+Chose utile, que ne fournissent pas les autotools, c'est une façon unifiée de gérer le numéro de version de l'application ; Toutes les variables d'un CMakeLists peuvent être utilisées pour générer des fichiers à partir de templates (souvent le nom du fichier avec le suffixe .in). En pratique, on définit VERSION_MAJOR et VERSION_MINOR, puis on génère un Version.h, un doxyfile, et on utilise les valeurs pour générer les noms des bibliothèques exportées. C'est simple, intuitif, et très bien expliqué dans le tutoriel. Faire une release se limite alors à changer le numéro de version dans un fichier, et de lancer la compilation pour obtenir les binaires et packages.
 
 CMake dispose aussi d'un système de macros, pour faciliter la vie des maintainers, et l'on comprend donc que de plus en plus de projets tendent à l'utiliser.
 
 Un fichier de configuration emacs est disponible (depuis la doc de cmake) pour ajouter un "cmake-mode", et se charge avec, par exemple, `(load "~/.emacs.d/cmake-mode.el")`.
 
-On peux aussi contrôler la génération d'une documentation avec doxygen. Pour cela, on rajoute un CMakeListes dans un répertoire /doc. On demande à ce que doxygen soit présent via `find_package(Doxygen)`. On écrit un fichier template doxygen.in de configuration, où les valeurs à modifier sont de la forme @NOM_DUN_DEFINE@, et définies dans le fichier de fonfiguration CMake par `set(NOM_DUN_DEFINE pouïc)`. Ensuite, on peut facilement ajouter une règle "make doc" de la façon suivante :
+On peut aussi contrôler la génération d'une documentation avec doxygen. Pour cela, on rajoute un CMakeLists dans un répertoire /doc. On demande à ce que doxygen soit présent via `find_package(Doxygen)`. On écrit un fichier template doxygen.in de configuration, où les valeurs à modifier sont de la forme @NOM_DUN_DEFINE@, et définies dans le fichier de configuration CMake par `set(NOM_DUN_DEFINE pouïc)`. Ensuite, on peut facilement ajouter une règle "make doc" de la façon suivante :
 ```
 if(DOXYGEN_FOUND)
   configure_file(${DOXYGEN_TEMPLATE_FILE}
@@ -64,11 +64,11 @@ if(DOXYGEN_FOUND)
     )
 endif(DOXYGEN_FOUND)
 ```
-où le @ONLY signifie que seul les mots entouré d'@ seront remplacé (Sinon, les ${SOMETHING} sont aussi affectés).
+où le @ONLY signifie que seuls les mots entourés d'@ seront remplacés (Sinon, les ${SOMETHING} sont aussi affectés).
 
 ## Conclusion :
 
-Ce qu'il faut retenir, c'est que CMake est simple à configurer, offre de nombreuses fonctionnalités, et laisse la possibilité d'ajouter celles manquantes. Beaucoup de gens sont encore habitué au ./configure, et sont effrayé par cette nouvelle façon d'aborder ce problème. Pourtant, CMake est un réel gain de temps, et l'on voit des gros projets comme KDE changer de build system pour CMake.  On peux même l'utiliser pour de minuscule projets (compiler les .cpp d'un dossier en un exécutable, sans dépendances particulières, se fait avec un fichier de configuration de 3 lignes), et je vous encourage justement à le faire. Trois lignes pour avoir une gestion automatique des dépendances des .h, génération des makefiles, le tout multiplateforme, ce n'est pas cher payé.
+Ce qu'il faut retenir, c'est que CMake est simple à configurer, offre de nombreuses fonctionnalités, et laisse la possibilité d'ajouter celles manquantes. Beaucoup de gens sont encore habitués au ./configure, et sont effrayés par cette nouvelle façon d'aborder ce problème. Pourtant, CMake est un réel gain de temps, et l'on voit des gros projets comme KDE changer de build system pour CMake.  On peut même l'utiliser pour de minuscules projets (compiler les .cpp d'un dossier en un exécutable, sans dépendances particulières, se fait avec un fichier de configuration de 3 lignes), et je vous encourage justement à le faire. Trois lignes pour avoir une gestion automatique des dépendances des .h, génération des makefiles, le tout multiplateforme, ce n'est pas cher payé.
 
 ### Resources :
   * <http://en.wikipedia.org/wiki/CMake>

--- a/_posts/gdt-and-idt/2009-04-20-gdt-and-idt.md
+++ b/_posts/gdt-and-idt/2009-04-20-gdt-and-idt.md
@@ -2,47 +2,47 @@
 layout: post
 title: GDT et IDT
 description: Une courte introduction à la GDT(Global Descriptor Table) et
-  l'IDT(Interuption Descriptor Table) dans le cadre du développement d'un
-  bootloader/noyeau minimaliste.
+  l'IDT(Interruption Descriptor Table) dans le cadre du développement d'un
+  bootloader/noyau minimaliste.
 author: Jérémy Cochoy
 date: 2009-04-20 +0100
 categories: kernel asm software hardware embeded c
 lang: fr
 ...
 
-Depuis peu, le noyeau que je développe dispose enfin d'une gestion précaire des interruptions.
-Dans cette article je vais donc vous parler... interruptions!
+Depuis peu, le noyau que je développe dispose enfin d'une gestion précaire des interruptions.
+Dans cet article je vais donc vous parler... interruptions!
 Et histoire de ne perdre personne, on commencera par décrire le fonctionnement de la
 GDT.
 
 ## 1 : Physique ou Virtuelle
 
 Si vous avez déjà fait un peu d'assembleur, vous savez peut-être qu'un programme,
-une fois en mémoire, est diviser en plusieurs segments :
+une fois en mémoire, est divisé en plusieurs segments :
 
  * Segment de code
- * Segment de donne
+ * Segment de données
  * Stack
 
-Pour accéder a ces différents segment, on dispose des Sélecteurs de Segment.
-Ce sont des registre qui indiquent à quel adresse mémoire situent les donnes.
+Pour accéder à ces différents segments, on dispose des Sélecteurs de Segment.
+Ce sont des registres qui indiquent à quelle adresse mémoire se situent les données.
 
-Ainsi, pour accéder a l' octet numéro `0x03` du segment de code,
+Ainsi, pour accéder à l'octet numéro `0x03` du segment de code,
 on peut écrire `cs::0x03`.
-Quand l'ordinateur démarre, le processeur est en mode réelle.
-C' est a dire que les sélecteurs de segment représentent une adresse physique.
-(`0x73` représente l' adresse mémoire `0x730`)
+Quand l'ordinateur démarre, le processeur est en mode réel.
+C'est-à-dire que les sélecteurs de segment représentent une adresse physique.
+(`0x73` représente l'adresse mémoire `0x730`)
 
-Ce n'est pas vraiment super, tout les programmes ont accès à toute la mémoire,
-et de plus les registres sont limiter a 16bits... impossible
-d'accèder à toute la mémoire des ordinateurs actuel.
+Ce n'est pas vraiment super, tous les programmes ont accès à toute la mémoire,
+et de plus les registres sont limités à 16bits... impossible
+d'accéder à toute la mémoire des ordinateurs actuels.
 
 Pour régler ce problème, il existe le mode protégé,
-où le processeur est en 32Bits et ou les sélecteurs correspondent a un maillon
+où le processeur est en 32Bits et où les sélecteurs correspondent à un maillon
 de la GDT (on en reparlera dans quelques lignes).
 
-Dans le mode protéger, la valeur des sélecteurs correspond à
-l'offset (décalage par rapport a l'origine) de l' élément dans
+Dans le mode protégé, la valeur des sélecteurs correspond à
+l'offset (décalage par rapport à l'origine) de l'élément dans
 la GDT (Global Descriptor Table).
 Pour accéder au premier sélecteur de la GDT, on place donc 0x0 dans
 un sélecteur de segment.
@@ -55,32 +55,32 @@ l'exécution normale d'un
 [programme informatique](http://fr.wikipedia.org/wiki/Programme_informatique)
 par le [microprocesseur](http://fr.wikipedia.org/wiki/Microprocesseur).
 
-Les interruptions sont de deux type : matériel ou logiciel.
+Les interruptions sont de deux types : matériel ou logiciel.
 
-Une interruption matériel est typiquement l' appuis sur une touche du clavier.
-Une interruption logiciel peut être l' appelle à
+Une interruption matérielle est typiquement l'appui sur une touche du clavier.
+Une interruption logicielle peut être l'appel à
 un syscall (un appel à write sous unix)
 
-Pour associer une fonction(le sens informatique du terme) à chaque
-interruption, il existe l' IDT(Interrupt Descriptor Table).
+Pour associer une fonction (le sens informatique du terme) à chaque
+interruption, il existe l'IDT (Interrupt Descriptor Table).
 
-Chaque élément de l' IDT contient :
+Chaque élément de l'IDT contient :
 
  * Un sélecteur, qui correspond aux éléments de la GDT
  * Un offset (pointeur sur fonction)
- * Des bits qui spécifie le TYPE du maillon
+ * Des bits qui spécifient le TYPE du maillon
 
 ## 3 : IRQs
 
-Et non, ce n'est pas terminer. C'est bien beau de configurer la GDT et l' IDT,
+Et non, ce n'est pas terminé. C'est bien beau de configurer la GDT et l'IDT,
 mais encore faut-il configurer le chipset qui s'occupe de prévenir le processeur
-quand une interruption matériel a lieu.
-Pour résumer, ce composent envoi une requête (IRQ=Interuption ReQuest)
+quand une interruption matérielle a lieu.
+Pour résumer, ce composant envoie une requête (IRQ=Interruption ReQuest)
 au processeur quand un évènement a lieu.
-En plus, il n' est pas un, mais ils sont deux, en cascade (Un esclave et un maître).
+En plus, il n'est pas un, mais ils sont deux, en cascade (Un esclave et un maître).
 
-Une fois le tout configurer, on réactive les interruption et...
-On cherche pourquoi ça n' a pas fonctionner :)
+Une fois le tout configuré, on réactive les interruptions et...
+On cherche pourquoi ça n'a pas fonctionné :)
 
 ### 4 : Références
 

--- a/_posts/haskell-lazy-io/2013-07-16-haskell-lazy-io.md
+++ b/_posts/haskell-lazy-io/2013-07-16-haskell-lazy-io.md
@@ -9,16 +9,16 @@ categories: programming haskell language lazy io software script
 lang: fr
 ...
 
-Ces derniers jours, j'écrivais un script haskell qui repère les fichiers présent en double, et propose de ne conserver qu'un exemplaire. Très pratique pour faire un peu de rangement, par exemple parmi une centaine de PDF que je ne lirais jamais.
+Ces derniers jours, j'écrivais un script haskell qui repère les fichiers présents en double, et propose de ne conserver qu'un exemplaire. Très pratique pour faire un peu de rangement, par exemple parmi une centaine de PDF que je ne lirais jamais.
 
-Je vais ici vous parler de la phase de hachage des fichiers pour les trier et déterminer les doublons. Et oui, on ne vas pas comparer le contenu de tous les fichiers entre eux, ça serait en n^2 par rapport au nombre de fichiers. On ne veux pas non plus attendre une journée.
+Je vais ici vous parler de la phase de hachage des fichiers pour les trier et déterminer les doublons. Et oui, on ne va pas comparer le contenu de tous les fichiers entre eux, ça serait en n^2 par rapport au nombre de fichiers. On ne veut pas non plus attendre une journée.
 
-Je parlerais donc de la lecture du contenu des fichiers pour produire leur hash. Le trie des paires (Nom du fichier, hash) et l'affichage étant trivial et sans intérêt.
+Je parlerai donc de la lecture du contenu des fichiers pour produire leur hash. Le tri des paires (Nom du fichier, hash) et l'affichage étant trivial et sans intérêt.
 
 Strict IO ?
 ===========
 
-La première approche est souvent la plus simple. Nous voulons le hash d'un fichier? Et bien il suffit d'utiliser la fonction `hash :: String -> ByteString` du package `Crypto.Hash.SHA1` (SHA1, MD5, MD4, SHA256 ... celons vos gouts). Pour obtenir le contenue du fichier, on peux utiliser `readFile :: FilePath -> IO String`.
+La première approche est souvent la plus simple. Nous voulons le hash d'un fichier? Et bien il suffit d'utiliser la fonction `hash :: String -> ByteString` du package `Crypto.Hash.SHA1` (SHA1, MD5, MD4, SHA256 ... selon vos goûts). Pour obtenir le contenu du fichier, on peut utiliser `readFile :: FilePath -> IO String`.
 
 Cela nous donne :
 ``` {.haskell}
@@ -28,16 +28,16 @@ getHash filename = do
     return (filename, hashed)
 ```
 
-Il suffit alors d'appliquer `mapM getHash` sur une liste de nom de fichier pour obtenir une liste de couple Nomdufichier/Hashdufichier.
+Il suffit alors d'appliquer `mapM getHash` sur une liste de noms de fichiers pour obtenir une liste de couples Nomdufichier/Hashdufichier.
 
-Si l'on test, cela fonctionne très bien... jusqu'au moment où vous tombez sur un fichier de plus d'1GO. Là, `readFile` veux charger l'intégralité du fichier en mémoire. Et bien-sur, sur ma machine, c'est impossible.
+Si l'on test, cela fonctionne très bien... jusqu'au moment où vous tombez sur un fichier de plus d'1GO. Là, `readFile` veut charger l'intégralité du fichier en mémoire. Et bien sûr, sur ma machine, c'est impossible.
 
-La paresse a la rescousse!
+La paresse à la rescousse!
 ==========================
 
-On vous à toujours dis qu'être paresseux, c'était mal, improductif, et vous mènerais à votre perte? Et bien, ils avaient tort.
+On vous a toujours dit qu'être paresseux, c'était mal, improductif, et vous mènerait à votre perte? Et bien, ils avaient tort.
 
-On voudrais lire le fichier par morceau, et construire le hash avec ces morceaux (ce que toute bonne fonction de hachage permet).
+On voudrait lire le fichier par morceaux, et construire le hash avec ces morceaux (ce que toute bonne fonction de hachage permet).
 
 Pour ce qui est du hachage, on trouve dans `Crypto.Hash.Whatever` les trois fonctions :
 ``` {.haskell}
@@ -48,7 +48,7 @@ finalize :: Ctx -> S.ByteString
 
 Il nous faut donc un flux de `ByteString`. Pour ce faire, on dispose d'une version paresseuse de `ByteString`, qui se trouve dans le package `Data.ByteString.Lazy`. Histoire de fixer les notations et de ne pas se perdre entre les `ByteString` strict et les `ByteString` lazy, on parlera respectivement de `S.ByteString` et de `L.ByteString` (Strict/Lazy).
 
-Cela revient a importer les deux types de la façon suivante :
+Cela revient à importer les deux types de la façon suivante :
 ```haskell
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Lazy as L
@@ -60,28 +60,28 @@ L.readFile :: FilePath -> IO L.ByteString
 L.foldlChunks :: (a -> S.ByteString -> a) -> a -> L.ByteString -> a
 ```
 
-La première nous donne le contenue de notre fichier. La seconde, nous offre exactement la méthode qui "prend une fonction ajoutant un morceau de fichier au hash", puis "un hash vide", et enfin "une ByteString paresseuse". Cela parais plus évident si l'on spécialise les "a" en "Ctx".
+La première nous donne le contenu de notre fichier. La seconde, nous offre exactement la méthode qui "prend une fonction ajoutant un morceau de fichier au hash", puis "un hash vide", et enfin "une ByteString paresseuse". Cela paraît plus évident si l'on spécialise les "a" en "Ctx".
 
-On peux donc utiliser :
+On peut donc utiliser :
 ```haskell
 hashed <- fmap (finalize . foldlChunks update init) $ readFile filename
 ```
 
-Bon, en fait, il y avais plus simple. Il y a aussi la fonction :
+Bon, en fait, il y avait plus simple. Il y a aussi la fonction :
 ```haskell
 hashlazy :: L.ByteString -> S.ByteString
 ```
 qui produit le même résultat que notre pli.
 
-Et là tout fonctionne bien, nos fichier d'1Go sont haché.
+Et là tout fonctionne bien, nos fichiers d'1Go sont hachés.
 
-Mais ... si vous travaillez sur beaucoup de fichiers, vous risquez d'avoir un soucis. Par exemple, si vous testez sur `/usr/lib`, vous obtiendrez peut-être une jolie exception vous indiquant qu'il y a trop de filedescriptors utilisés, et que donc le fichier ne peux être ouvert.
-Il se trouve que les fichier ne sont pas fermé immédiatement après le hachage, et c'est un vrai problème. Problème que nous allons résoudre.
+Mais ... si vous travaillez sur beaucoup de fichiers, vous risquez d'avoir un soucis. Par exemple, si vous testez sur `/usr/lib`, vous obtiendrez peut-être une jolie exception vous indiquant qu'il y a trop de filedescriptors utilisés, et que donc le fichier ne peut être ouvert.
+Il se trouve que les fichiers ne sont pas fermés immédiatement après le hachage, et c'est un vrai problème. Problème que nous allons résoudre.
 
 La solution : withFile
 ======================
 
-La fonction `withFile :: FilePath -> IOMode -> (Handle -> IO r) -> IO r` est la clef. Cette fonction prend un nom de fichier, le mode d'ouverture (on utilisera ReadMode), une fonction qui travaille sur le fichier, et nous fait suivre le résultat de l'application de cette fonction. Un peu stupide, me direz vous? Et bien, ça le serait, si cette fonction se contenter de ça. En fait, elle vous assure aussi qu'une fois évaluée, le fichier est fermé. En l'utilisant, on est donc certain que le fichier est immédiatement fermé lorsque withFile est évalué en un "IO r".
+La fonction `withFile :: FilePath -> IOMode -> (Handle -> IO r) -> IO r` est la clef. Cette fonction prend un nom de fichier, le mode d'ouverture (on utilisera ReadMode), une fonction qui travaille sur le fichier, et nous fait suivre le résultat de l'application de cette fonction. Un peu stupide, me direz vous? Et bien, ça le serait, si cette fonction se contentait de ça. En fait, elle vous assure aussi qu'une fois évaluée, le fichier est fermé. En l'utilisant, on est donc certain que le fichier est immédiatement fermé lorsque withFile est évalué en un "IO r".
 
 ````haskell
 getHash filename = do
@@ -90,29 +90,29 @@ getHash filename = do
 return (filename, hashed)
 ```
 
-Le `unefonction $ \h -> do` est une pratique courante pour ces fonctions qui évalue un morceau de code dans un certains contexte. C'est très pratique, et on reconnaît très vite cette idiome avec un peu d'entraînement.
+Le `unefonction $ \h -> do` est une pratique courante pour ces fonctions qui évaluent un morceau de code dans un certain contexte. C'est très pratique, et on reconnaît très vite cet idiome avec un peu d'entraînement.
 
-On compile pour vérifier le typage, tout vas bien, et l'on lance donc notre application que l'on s'attend a voir fonctionner. Et là, c'est le drame : "Illegal operation : handle is closed".
+On compile pour vérifier le typage, tout va bien, et l'on lance donc notre application que l'on s'attend à voir fonctionner. Et là, c'est le drame : "Illegal operation : handle is closed".
 
-Wohw, quel est ce mystérieux message? Et bien, comme je vous l'ai dit, withFile ferme immédiatement le fichier après l'évaluation de son expression. Et que fait son évaluation? Elle retourne le hash du fichier me dite vous? Faut.
+Wohw, quel est ce mystérieux message? Et bien, comme je vous l'ai dit, withFile ferme immédiatement le fichier après l'évaluation de son expression. Et que fait son évaluation? Elle retourne le hash du fichier me dites-vous? Faux.
 
-La fonction construit un thunk (je parlerais de promesse de calcul, ou plus simplement de promesse) a l'aide de "fmap ...". L’évaluation de withFile retourne alors cette promesse, plutôt que la valeur du hash. Et cette promesse, elle, ne sera évaluée que plus tard, au moment ou vous en aurez vraiment besoin, et seulement si vous en avez besoin.
+La fonction construit un thunk (je parlerais de promesse de calcul, ou plus simplement de promesse) a l'aide de "fmap ...". L’évaluation de withFile retourne alors cette promesse, plutôt que la valeur du hash. Et cette promesse, elle, ne sera évaluée que plus tard, au moment où vous en aurez vraiment besoin, et seulement si vous en avez besoin.
 
-Il nous faut donc forcer haskell a être strict, et évaluer le hash avant de sortir de la fonction. Il y a différentes façons de le faire. La plus simple, c'est d'utiliser l'opérateur `` `seq` `` qui force l'évaluation de l'expression a sa gauche, puis retourne l'expression a sa droite. On a aussi l’opérateur `` a ($!) b = b `seq` (a b) `` qui est une "application stricte". C'est a dire que ce qui sera a droite de `$!` sera évalué. 
+Il nous faut donc forcer haskell à être strict, et évaluer le hash avant de sortir de la fonction. Il y a différentes façons de le faire. La plus simple, c’est d’utiliser l’opérateur `` `seq` `` qui force l’évaluation de l’expression à sa gauche, puis retourne l’expression à sa droite. On a aussi l’opérateur `` a ($!) b = b `seq` (a b) `` qui est une "application stricte". C’est-à-dire que ce qui sera à droite de `$!` sera évalué. 
 
-Nb : Il faut faire attention. Quand je dis évalué, je parle bien de _dé-construire_ le premier niveau de l'expression. C'est a dire que si `compute 1 42` est un calcul, ceci sera remplacer par la promesse ou le résultat retournée par compute. Si compute produit une promesse plutôt qu'un résultat, l'opérateur `` `seq` `` n'évaluera pas la promesse. Il existe un opérateur `` `deepSeq` ``, qui lui vas _tout réduire_ en profondeur. Comme vous vous en doutez, c'est très coûteux et évalue des choses dont on n'auras peut-être pas besoin. Le plus souvent, on peux se contenter de `` `seq` `` appliqué au bonne endroit pour obtenir le résultat souhaité.
+Nb : Il faut faire attention. Quand je dis évalué, je parle bien de _dé-construire_ le premier niveau de l'expression. C'est-à-dire que si `compute 1 42` est un calcul, ceci sera remplacé par la promesse ou le résultat retourné par compute. Si compute produit une promesse plutôt qu'un résultat, l'opérateur `` `seq` `` n'évaluera pas la promesse. Il existe un opérateur `` `deepSeq` ``, qui lui va _tout réduire_ en profondeur. Comme vous vous en doutez, c'est très coûteux et évalue des choses dont on n'aura peut-être pas besoin. Le plus souvent, on peut se contenter de `` `seq` `` appliqué aux bons endroits pour obtenir le résultat souhaité.
 
-Dans notre cas, il faudrait forcer la promesse faire par `fmap` a être évaluée, puis la promesse faite par `hashlazy`. Vous allez voir que la solution n'est pas plus compliquée que ce que nous avions déjà écrit :
+Dans notre cas, il faudrait forcer la promesse faite par `fmap` à être évaluée, puis la promesse faite par `hashlazy`. Vous allez voir que la solution n'est pas plus compliquée que ce que nous avions déjà écrit :
 
 ```haskell
 -- getHash ...
     withFile filename ReadMode $ \h -> do
         -- On obtient la promesse faite par hashlazy
         data <- fmap hashlazy $ hGetContents h
-        -- On force l'évaluation de hashlazy, qui donc sera forcé d'ouvrir le fichier et de le lire, puisque la valeur retournée est un S.ByteString, une valeur Stricte.
+        -- On force l'évaluation de hashlazy, qui donc sera forcée d'ouvrir le fichier et de le lire, puisque la valeur retournée est un S.ByteString, une valeur Stricte.
         return $! data
 ```
 
 Voila, c'est tout, c'est `$!` qui fait tout le travail en demandant à hashlazy de gentiment s'évaluer.
 
-Et la c'est le bonheur, tout refonctionne et l'on peux gérer des fichiers arbitrairement grand en nombre arbitrairement grand, le tout en 4 lignes.
+Et là c'est le bonheur, tout refonctionne et l'on peut gérer des fichiers arbitrairement grands en nombre arbitrairement grand, le tout en 4 lignes.

--- a/_posts/haskell-pure-1/2013-04-07-haskell-pure-1.md
+++ b/_posts/haskell-pure-1/2013-04-07-haskell-pure-1.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Le Haskell, un langage au label pure. Première partie.
-description: Inroduction à haskell (partie 1). On discute curryfication, typage, et pattern matching.
+description: Introduction à haskell (partie 1). On discute curryfication, typage, et pattern matching.
 author: Jérémy Cochoy
 date: 2013-04-07 +0100
 categories: programming haskell language software
@@ -15,13 +15,13 @@ redirect_from:
   - /blog/haskell-pure-1/fr.htm
 ...
 
-Mauvais jeux de mots mit à part, ce très court et succin billet (vous me voyez venir) va traiter du haskell. Haskell, de monsieur Haskell Brook Curry, un monsieur très épicé, est un langage fonctionnel. Comme beaucoup de langages fonctionnel, cela représente un choque culturel que de les appréhender. Mais le haskell semble avoir un petit quelque chose que n'ont pas les autres langages fonctionnels. À travers les trois prochains billets, j'espère vous convaincre que, si un jour, dans votre vie, vous avez l'occasion de creuser un language fonctionnel, alors vous devriez creuser le haskell.
+Mauvais jeux de mots mis à part, ce très court et succinct billet (vous me voyez venir) va traiter du haskell. Haskell, de monsieur Haskell Brook Curry, un monsieur très épicé, est un langage fonctionnel. Comme beaucoup de langages fonctionnels, cela représente un choc culturel que de les appréhender. Mais le haskell semble avoir un petit quelque chose que n'ont pas les autres langages fonctionnels. À travers les trois prochains billets, j'espère vous convaincre que, si un jour, dans votre vie, vous avez l'occasion de creuser un langage fonctionnel, alors vous devriez creuser le haskell.
 
 La [seconde partie est disponible ici](http://zenol.fr/site/blog/posts/haskell-pure-2/fr.htm "Le Haskell, un langage au label pure. Seconde partie.").
 
-On y vas tout en douceur. Curryfication et typage, pour ceux qui n'ont pas déjà découvert les joies (les dolipranes?) qu'apportent ces derniers. Si vous avez déjà eu à toucher à des langages fonctionnels, vous souhaiterez sûrement passer directement à la seconde partie où j'aborderais les diverses fonctionnalités original du haskell, comme les fameuses liste infinies dont tout le monde parle, mais dont trop peu se doutent de l'utilité. On parleras de data driven programming, de fonctions sans effets de bord et de parallélisation des calculs en haskell (avec un VRAI exemple!). Enfin, apogée, moment de transe et de plaisir inégale, on abordera la huitième merveille du monde : les monades.
+On y va tout en douceur. Curryfication et typage, pour ceux qui n'ont pas déjà découvert les joies (les dolipranes?) qu'apportent ces derniers. Si vous avez déjà eu à toucher à des langages fonctionnels, vous souhaiterez sûrement passer directement à la seconde partie où j'aborderai les diverses fonctionnalités originales du haskell, comme les fameuses liste infinies dont tout le monde parle, mais dont trop peu se doutent de l'utilité. On parlera de data driven programming, de fonctions sans effets de bord et de parallélisation des calculs en haskell (avec un VRAI exemple!). Enfin, apogée, moment de transe et de plaisir inégalé, on abordera la huitième merveille du monde : les monades.
 
-## Ce que tout le monde sais déjà... ou pas.
+## Ce que tout le monde sait déjà... ou pas.
 
 Faisons un petit retour sur ce que l'on retrouve dans tous les langages fonctionnels, et ce qui les rend si différents.
 
@@ -36,7 +36,7 @@ addOne :: (Num n) => n -> n
 addOne a = a + 42
 ```
 
-La première ligne est le typage de la fonction (souvent facultatif), et la seconde est le corps de la fonction. En C++, ça donnerais :
+La première ligne est le typage de la fonction (souvent facultatif), et la seconde est le corps de la fonction. En C++, ça donnerait :
 ```c++
 template <class T>
 T mult(T a, T b)
@@ -52,30 +52,30 @@ T addOne(T a)
 
 En fait, le `n` qui apparaît dans le type peut être remplacé par n'importe quel lettre/mot qui vous plaît. Cela signifie un type quelconque, qui respecte la contrainte "_peut être multiplié_" décrite par `(Num n) =>`.
 
-La présence de `Num` correspond à la nécessiter d'avoir, dans le code c++, une surcharge de l'opérateur *. Remarquez qu'une fonction en haskell correspond naturellement a une fonction template, à moins de forcer les types à être moins "puissant", comme par exemple :
+La présence de `Num` correspond à la nécessité d'avoir, dans le code c++, une surcharge de l'opérateur *. Remarquez qu'une fonction en haskell correspond naturellement à une fonction template, à moins de forcer les types à être moins "puissants", comme par exemple :
 ```haskell
 mult :: Int -> Int -> Int
 mult a b = a * b
 ```
 
-Qui ne sais plus que multiplier des entiers.
+Qui ne sait plus que multiplier des entiers.
 
 ### Curryfication
 
-La curryfication est essentiellement un changement de point de vue. On peux considérer une fonctions prenant deux nombres, et retournant une valeur. Mais on peut aussi changer de point de vue et considérer une fonction prenant un nombre, et renvoyant une nouvelle fonction, prenant un nombre, et retournant une valeur.
+La curryfication est essentiellement un changement de point de vue. On peut considérer une fonction prenant deux nombres, et retournant une valeur. Mais on peut aussi changer de point de vue et considérer une fonction prenant un nombre, et renvoyant une nouvelle fonction, prenant un nombre, et retournant une valeur.
 
 Cela explique l'étrange notation pour le type de la fonction mult. En fait, l'opérateur "->" est associatif à droite, c'est à dire qu'il fallait lire :
 ```haskell
 mult :: (Num n) => n -> (n -> n)
 ```
 
-Où `X -> Y` indique que la fonction prend du type X et retourne du type Y. Ainsi, `n -> n` signifie prend un type n quelconque et renvoi quelque chose du même type. C'est le type d'une fonction. Si l'on veux un exemple plus concret, `Int-> (Float->Double)` signifie une fonction qui prend un entier, puis renvoi une nouvelle fonction. Cette dernière prend un float et le transforme en un double.
+Où `X -> Y` indique que la fonction prend du type X et retourne du type Y. Ainsi, `n -> n` signifie prend un type n quelconque et renvoie quelque chose du même type. C'est le type d'une fonction. Si l'on veut un exemple plus concret, `Int-> (Float->Double)` signifie une fonction qui prend un entier, puis renvoie une nouvelle fonction. Cette dernière prend un float et le transforme en un double.
 
 Partant de ce point de vue, il est très simple de fixer les premiers arguments d'une fonction curryfiée. L'application d'un élément à un autre étant associatif à gauche, il suffit de l'appeler avec une partie de ses arguments. (Et oui, puisque écrire `mult a b` signifie alors `((mult a) b)`. C'est à dire appliquer `mult` à `a` pour obtenir une fonction qui "_prend un entier et le multiplie par a_", puis évaluer cette fonction sur l'entier b.)
 
 Par exemple, `nouvelle_fonction = mult 42` correspond à fixer la première valeur de la fonction `mul` à `42`.
 
-En C++, il faudrais écrire
+En C++, il faudrait écrire
 ```c++
 template<class T>
 T nouvelle_fonction(T b)
@@ -86,17 +86,17 @@ T nouvelle_fonction(T b)
 
 Pour finir, puisque l'on est en plein dans la manipulation de fonctions, on peut écrire une fonction comme une valeur, et la stocker dans une "variable".
 ```haskell
--- Pour écrire une fonction "anonyme", qui prend trois arguments et renvoi 42, on peut écrire
+-- Pour écrire une fonction "anonyme", qui prend trois arguments et renvoie 42, on peut écrire
 -- (\x y z -> 42)
 -- Où x y z seront les trois arguments, et ce qui suit -> est la "valeur de retour".
--- On aurais donc pu écrire la fonction mult de la façon suivante :
+-- On aurait donc pu écrire la fonction mult de la façon suivante :
 mult = (\a b -> a * b) :: (Num n) => n -> n -> n
 
 --On peut aussi écrire \a -> \b -> à la place de \a b, grâce à la curryfication.
 ```
-Le typage est bien sur facultatif.
+Le typage est bien sûr facultatif.
 
-On a alors deux petites fonctions bien pratique pour manipuler des fonctions ; l'identité et la composition :
+On a alors deux petites fonctions bien pratiques pour manipuler des fonctions ; l'identité et la composition :
 ```haskell
 id = \x -> x
 a . b = \x -> a (b x)
@@ -108,7 +108,7 @@ add a b = a + b
 superFct = mult 2 . add 3
 ```
 
-Enfin, on aurais pu écrire :
+Enfin, on aurait pu écrire :
 ```haskell
 mult = (*)
 add = (+)
@@ -117,16 +117,16 @@ superFct = (2*) . (3+)
 
 ### Typage
 
-Les types, en langage fonctionnel, disent beaucoup de choses, et sont lourd de sens.
+Les types, en langage fonctionnel, disent beaucoup de choses, et sont lourds de sens.
 En haskell, une liste d'entiers se note `[Int]`. Si `a` est un type, alors une liste de `a` est de type `[a]`. Les chaînes de caractères sont par exemple des `[Char]`.
 
-Alors, que devrait faire une fonction de type `(a -> b) -> [a] -> [b]`? Et bien, elle prend une fonction _transformant du a en b_ que l'on appellera f, une _liste de a_, et produit une _liste de b_. Le bon sens veux que cette fonction applique f à chaque élément de la _liste de a_, pour produire une _liste de b_.
+Alors, que devrait faire une fonction de type `(a -> b) -> [a] -> [b]`? Et bien, elle prend une fonction _transformant du a en b_ que l'on appellera f, une _liste de a_, et produit une _liste de b_. Le bon sens veut que cette fonction applique f à chaque élément de la _liste de a_, pour produire une _liste de b_.
 
-Encore un, pour la route. Que dire du type `[[a]] -> [a]`? On prend une _liste de liste_, et on produit _une liste_. La première chose qui nous vient à l'esprit est de concaténer toute ces listes les unes à la suite des autres pour n'en produire plus qu'une.
+Encore un, pour la route. Que dire du type `[[a]] -> [a]`? On prend une _liste de liste_, et on produit _une liste_. La première chose qui nous vient à l'esprit est de concaténer toutes ces listes les unes à la suite des autres pour n'en produire plus qu'une.
 
 Voyez tout ce qu'on peut deviner sur le comportement d'une fonction grâce aux types.
 
-Pour éviter les noms à rallonge, on peu aussi construire des alias de type. Plutôt que décrire `[Char]`, on peut écrire `String`, définit par :
+Pour éviter les noms à rallonge, on peut aussi construire des alias de type. Plutôt que décrire `[Char]`, on peut écrire `String`, défini par :
 ```haskell
 type String = [Char]
 ```
@@ -143,9 +143,9 @@ getSomeone :: Nom -> Prenom -> Identifiant
 Grâce à ces alias, vous avez une idée claire du comportement de la fonction getSomeone simplement en lisant son type.
 
 Mais le meilleur est à venir : les constructeurs de type.
-Attention, un constructeur en haskell est tout sauf un constructeur C++. Ça se rapprocherais plutôt de la structure, et encore...
+Attention, un constructeur en haskell est tout sauf un constructeur C++. Ça se rapprocherait plutôt de la structure, et encore...
 
-Pou faire bref, les constructeur permettent de fabriquer des instances d'un type. Considérons quelques types :
+Pour faire bref, les constructeurs permettent de fabriquer des instances d'un type. Considérons quelques types :
 ```haskell
 data Personne = ConstructeurDePersonne Nom Prenom Identifiant
 data Reponse = Oui | Non
@@ -154,7 +154,7 @@ data ListeEntier = Element Int Liste | Vide
 data ArbreEntier = Noeud Int Arbre Arbre | Vide
 ```
 
-Le premier type, `Personne`, est une structure à trois champs. Le second, est un type booléen, qui peut soit être construit par le constructeur _Oui_, soit par le constructeur _Non_. Le troisième est une union pouvant contenir un `Int` ou un `Float`, et les derniers sont respectivement un type liste d'entier et arbre binaire d'entier. Le système de types permet de considérer des objets plus proche des données représentée, et de s'abstraire de l'implémentation.
+Le premier type, `Personne`, est une structure à trois champs. Le second, est un type booléen, qui peut soit être construit par le constructeur _Oui_, soit par le constructeur _Non_. Le troisième est une union pouvant contenir un `Int` ou un `Float`, et les derniers sont respectivement un type liste d'entier et arbre binaire d'entier. Le système de types permet de considérer des objets plus proches des données représentées, et de s'abstraire de l'implémentation.
 
 Donnons une correspondance C++ des deux derniers exemples dans leur version "polymorphique", où Liste et Arbre deviennent des constructeurs de type, et prennent donc en paramètre le type qu'ils doivent contenir.
 ```haskell
@@ -202,9 +202,9 @@ uneListe = Element 1 ( Element 2 ( Element 3 ( Element 4 Vide ) ) )
 racine = Noeud 4 (Noeud 2 Vide Vide) (Noeud 6 Vide Vide)
 ```
 
-### Patern matching
+### Pattern matching
 
-Si l'on peut construire des types, on peut aussi les détruire, où plus précisément, les dès-construire. Partant d'un objet de type liste, on peut vouloir récupérer le première élément, si la liste n'est pas vide. Cela se fait en faisant matcher un pattern sur l'instance d'un type :
+Si l'on peut construire des types, on peut aussi les détruire, où plus précisément, les dé-construire. Partant d'un objet de type liste, on peut vouloir récupérer le premier élément, si la liste n'est pas vide. Cela se fait en faisant matcher un pattern sur l'instance d'un type :
 
 ```haskell
 obtenirNom (ConstructeurDePersonne nom _ _) = nom
@@ -226,7 +226,7 @@ recupererValeur' truc = let (Entier v) = truc in v
 
 __Nb :__ Le caractère ' est un caractère valide comme un autre pour un nom de fonction ou de variable (bien qu'en fait, en haskell, il n'existe pas de variable au sens usuel).
 
-Voilà, ce seras tout pour aujourd'hui :)
+Voilà, ce sera tout pour aujourd'hui :)
 
 Références :
 ------------

--- a/_posts/haskell-pure-2/2013-04-22-haskell-pure-2.md
+++ b/_posts/haskell-pure-2/2013-04-22-haskell-pure-2.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Le Haskell, un langage au label pure. Seconde partie.
-description: Inroduction à haskell (partie 2). On y discute
+description: Introduction à haskell (partie 2). On y discute
   listes infinies, data driven programming et foncteurs.
 author: Jérémy Cochoy
 date: 2013-04-22 +0100
@@ -9,7 +9,7 @@ categories: programming haskell language software
 lang: fr
 ...
 
-Nous continuons de découvrir des paysages fonctionnels à travers le Haskell. Cette fois, nous nous éloignons des généralités et rentrons dans le vif du sujet en nous intéressant à des aspects plus propre au haskell (bien que d'autres langages fonctionnels implémentent des fonctionnalités similaires).
+Nous continuons de découvrir des paysages fonctionnels à travers le Haskell. Cette fois, nous nous éloignons des généralités et rentrons dans le vif du sujet en nous intéressant à des aspects plus propres au haskell (bien que d'autres langages fonctionnels implémentent des fonctionnalités similaires).
 
 La [première partie est disponible ici](/haskell-pure-1/ "Le Haskell, un langage au label pure. Première partie."). La [troisième là](/haskell-pure-3/ "Le Haskell, un langage au label pure. Troisième partie.").
 
@@ -17,15 +17,15 @@ La [première partie est disponible ici](/haskell-pure-1/ "Le Haskell, un langag
 
 ### Les listes infinies (et listes en compréhension)
 
-Les listes infinies sont une des nombreuses possibilités offertes par un langage paresseux. C'est souvent d'elles dont on entend le plus parler pour présenter le haskell, alors qu'il ne s'agit pourtant que d'une fonctionnalité original parmi tant d'autres. Cela est sûrement du au fait que la notion d'infinie éveille la curiosité des développeurs habitué à un monde impératif où les tableaux, les listes, et toute structure mémoire est finie.
+Les listes infinies sont une des nombreuses possibilités offertes par un langage paresseux. C'est souvent d'elles dont on entend le plus parler pour présenter le haskell, alors qu'il ne s'agit pourtant que d'une fonctionnalité originale parmi tant d'autres. Cela est sûrement dû au fait que la notion d'infini éveille la curiosité des développeurs habitués à un monde impératif où les tableaux, les listes, et toute structure mémoire est finie.
 
-Le principe est relativement simple : vous définissez une liste, que ce soit de façon récursive ou simplement par compréhension (on vas voir ce que cela signifie dans quelques lignes), puis seulement les éléments de la liste dont le programme auras besoin seront évalué. Les autres ne seront jamais calculés.
+Le principe est relativement simple : vous définissez une liste, que ce soit de façon récursive ou simplement par compréhension (on va voir ce que cela signifie dans quelques lignes), puis seulement les éléments de la liste dont le programme aura besoin seront évalués. Les autres ne seront jamais calculés.
 
-Comment faire de telles listes? La façon la plus simple est la définition de liste par compréhension, c'est à dire une définition de la forme "L'ensemble des f(trucs) pour les quels P(truc) est vraie". Où f est une formule sur "trucs" et où P est une proposition, disons une fonction qui renvoie True ou False.
+Comment faire de telles listes? La façon la plus simple est la définition de liste par compréhension, c'est à dire une définition de la forme "L'ensemble des f(trucs) pour lesquels P(truc) est vraie". Où f est une formule sur "trucs" et où P est une proposition, disons une fonction qui renvoie True ou False.
 
 Par exemple :
 ``` haskell
--- "x <- l" signifit "pour x se baladant dans la liste l"
+-- "x <- l" signifie "pour x se baladant dans la liste l"
 -- l1 = [1, 2, 3, 4, 5]
 l1 = [x | x <- [1, 2, 3, 4, 5]]
 -- L'opérateur c/c++ != s'écrit /= 
@@ -39,9 +39,9 @@ l2 = [2^x | x <- [1, 2, 3, 4, 5]]
 l4 = [2^x | x <- [1, 2, 3, 4, 5], x /= 3]
 ```
 
-En fait, c'est une sorte de sucre syntaxique. Le soucis, c'est que ce que cache les listes en compréhension ne seras aborder que dans la troisième partie. On se contenteras donc de la signification et de la façon dont on l'utilise.
+En fait, c'est une sorte de sucre syntaxique. Le soucis, c'est que ce que cachent les listes en compréhension ne sera abordé que dans la troisième partie. On se contentera donc de la signification et de la façon dont on l'utilise.
 
-Pour en revenir a nos listes en compréhension infinie, on peut penser à "L'ensemble des entiers qui sont paire" par exemple. Voici quelques listes infinies :
+Pour en revenir à nos listes en compréhension infinie, on peut penser à "L'ensemble des entiers qui sont pairs" par exemple. Voici quelques listes infinies :
 ``` haskell
 --La liste de tous les entiers à partir de 42 peut s'écrire [42..]
 liste_infinie_des_entiers = [1..]
@@ -49,25 +49,25 @@ liste_infinie_des_entiers = [1..]
 --Pour calculer x % 2 (c/c++), on écrit "x `mod` 2", ou encore "mod x 2".
 
 liste_des_entiers_paires = [2 * x | x <- [1..]]
--- On peut rajouter des conditions séparé par des virgules
+-- On peut rajouter des conditions séparées par des virgules
 liste_des_entiers_paires' = [x | x <- [1..], x `mod` 2 == 0]
 
 -- On peut utiliser plusieurs variables se baladant dans différentes listes :
 liste_de_produit = [x * y | x <- [1..5], y <- [1..]]
 ```
 
-Une autre façon de définir une liste est d'utiliser la récusivité. Voici quelques exemples.
+Une autre façon de définir une liste est d'utiliser la récursivité. Voici quelques exemples.
 ``` haskell
 --"map f l" applique la fonction f sur chaque élément de la liste l
 -- [a, b] est du sucre syntaxique pour a : b : [].
 entiers = 1 : (map (1+) entiers)
 ```
 
-Regardons se qui se passe si l'on demande les trois premiers éléments de la liste, ce qui se fait avec `take 3 l`. D'abord, il lit `1 :` et connais donc le premier élément. Pour avoir le second, il lit `(map (1+) entiers)`. Il applique donc map sur la liste, mais de façon paresseuse, c'est a dire qu'en ne calculant que l'application sur le premier terme. Il obtient donc `(1+)(1) = 2`. puis, pour avoir le troisième élément, il doit appliquer `(1+)` au deuxième élément de la liste entier. Ça tombe bien, on vient de le calculer, c'est `2`. On a donc pour troisième élément `(1+)(2) = 3`.
+Regardons ce qui se passe si l'on demande les trois premiers éléments de la liste, ce qui se fait avec `take 3 l`. D'abord, il lit `1 :` et connaît donc le premier élément. Pour avoir le second, il lit `(map (1+) entiers)`. Il applique donc map sur la liste, mais de façon paresseuse, c'est-à-dire en ne calculant que l'application sur le premier terme. Il obtient donc `(1+)(1) = 2`. puis, pour avoir le troisième élément, il doit appliquer `(1+)` au deuxième élément de la liste entier. Ça tombe bien, on vient de le calculer, c'est `2`. On a donc pour troisième élément `(1+)(2) = 3`.
 
-De cette façon, on aurais aussi pu définir la liste des entiers pairs, la liste des nombres de fibonacci (même si on ne voit pas bien l’intérêt dans un programme), ou la liste des nombres premiers (plus difficile).
+De cette façon, on aurait aussi pu définir la liste des entiers pairs, la liste des nombres de fibonacci (même si on ne voit pas bien l’intérêt dans un programme), ou la liste des nombres premiers (plus difficile).
 
-Bon, c'est très beau tout ça, mais est-ce que ça sert vraiment (parce que, faire des listes infinies pour faire des listes infinies...)? Oui, ça sert, et voici un exemple simple et concret. Disons que vous participez au Google Code Jam. Vous devez fournir des réponse en respectant un certain format. Plus précisément, on vous donne une entrée de n éléments à traiter, par exemple n lignes contenant chacune un nombre, et vous devez fournir le résultat de votre traitement sous la forme _Case #i: <vos données>\n_. En C++, on aurais itéré sur la liste de résultat (ou directement l'entrée) et provoqué l'écriture de "Case #i" sur la sortie standard juste avant celle de vos données. En haskell, on peut (doit?) faire ça différemment (J'ai honteusement pompé ce que propose un développeur sur [youtube](http://www.youtube.com/watch?v=_tgv3HVgOMc)) :
+Bon, c'est très beau tout ça, mais est-ce que ça sert vraiment (parce que, faire des listes infinies pour faire des listes infinies...)? Oui, ça sert, et voici un exemple simple et concret. Disons que vous participez au Google Code Jam. Vous devez fournir des réponses en respectant un certain format. Plus précisément, on vous donne une entrée de n éléments à traiter, par exemple n lignes contenant chacune un nombre, et vous devez fournir le résultat de votre traitement sous la forme _Case #i: <vos données>\n_. En C++, on aurait itéré sur la liste de résultats (ou directement l'entrée) et provoqué l'écriture de "Case #i" sur la sortie standard juste avant celle de vos données. En haskell, on peut (doit?) faire ça différemment (J'ai honteusement pompé ce que propose un développeur sur [youtube](http://www.youtube.com/watch?v=_tgv3HVgOMc)) :
 ``` haskell
 boilerPlate :: [String]
 boilerPlate = ["Case #" ++ show n ++ ": " | n <- [1..]]
@@ -81,30 +81,30 @@ standardOutput = zipWith (++) boilerPlate
 -- Une fois votre sortie sous la forme d'une liste de String, il vous suffit de la donner à standardOutput pour obtenir le formatage attendu
 ```
 
-On voit ici que la liste infinie boilerPlate contient tous les formatages possibles. Bien entendu, à chaque exécution, il n'y auras qu'un nombre finie d'entrées et de sorties, donc une partie finie de la liste qui seras utilisé.
+On voit ici que la liste infinie boilerPlate contient tous les formatages possibles. Bien entendu, à chaque exécution, il n'y aura qu'un nombre fini d'entrées et de sorties, donc une partie finie de la liste qui sera utilisée.
 
 ### Data-driven programming
 
-En haskell, manipuler des listes ou des structures similaires est chose courante, et il y a un bon nombre de fonction dédiés. Par exemple `map f l` qui permet d'appliquer `f` sur les éléments de `l`, `zip` et `zipWith` qui permettent de souder deux liste en une unique (soit sous forme de liste de couple, soit en utilisant la fonction que vous fournissez). Mais ce n'est pas tout. Nous ne parlerons par exemple pas de `foldr` et `foldl` qui permettent a partir d'une liste d'éléments de l'écraser en un nouvel élément grâce à une fonction que vous fournissez (leurs usages est multiple. On peut implémenter facilement la somme/produit des éléments d'une liste, la conversion d'une liste de mot en une seul chaine de caractère, la transformation d'une liste en un arbre binaire de recherche, etc).
+En haskell, manipuler des listes ou des structures similaires est chose courante, et il y a un bon nombre de fonctions dédiées. Par exemple `map f l` qui permet d'appliquer `f` sur les éléments de `l`, `zip` et `zipWith` qui permettent de souder deux listes en une unique (soit sous forme de liste de couple, soit en utilisant la fonction que vous fournissez). Mais ce n'est pas tout. Nous ne parlerons par exemple pas de `foldr` et `foldl` qui permettent à partir d'une liste d'éléments de l'écraser en un nouvel élément grâce à une fonction que vous fournissez (leurs usages est multiple. On peut implémenter facilement la somme/produit des éléments d'une liste, la conversion d'une liste de mots en une seule chaîne de caractères, la transformation d'une liste en un arbre binaire de recherche, etc).
 
-Vous devriez avoir remarquer qu'en haskell, on aime bien concevoir de petites fonctions travaillant sur un élément de type a, et produisant un élément de type b, puis appliquer ces petites fonctions sur les éléments de structures de donnés plus ou moins complexe. Cela a de nombreux avantages :
+Vous devriez avoir remarqué qu'en haskell, on aime bien concevoir de petites fonctions travaillant sur un élément de type a, et produisant un élément de type b, puis appliquer ces petites fonctions sur les éléments de structures de données plus ou moins complexes. Cela a de nombreux avantages :
 -Il est plus simple de concevoir une fonction de type Int->String qu'une fonction de type `[Int] -> [(String, Int)]`, par exemple.
--On est plus générique ; Si l'on sais transformer du a en b, alors on sais transformer du `[a]` en `[b]` et du `Tree a` en `Tree b` (où `Tree a` est un arbre binaire où chaque noeud contient un élément de type a).
--En cas de changement de structure mémoire, par exemple pour des raisons de performances, on minimise l'impacte sur le code à modifier. Si l'on souhaite passer de liste à des arbres, seul le traitement effectué sur les listes devras être ré-écrit pour les arbres, mais rien d'autre.
+-On est plus générique ; Si l'on sait transformer du a en b, alors on sait transformer du `[a]` en `[b]` et du `Tree a` en `Tree b` (où `Tree a` est un arbre binaire où chaque noeud contient un élément de type a).
+-En cas de changement de structure mémoire, par exemple pour des raisons de performances, on minimise l'impact sur le code à modifier. Si l'on souhaite passer de listes à des arbres, seul le traitement effectué sur les listes devra être ré-écrit pour les arbres, mais rien d'autre.
 
-On se retrouve donc à se concentrer plus sur les types qu'on manipule que la façon dont on les manipule. C'est à dire que l'on dispose d'un nombre important de façon simple de transformer certaines données en d'autres, et les points cruciaux sont alors de:
--Bien choisir la façon dont seront représentés les données traitées
+On se retrouve donc à se concentrer plus sur les types qu'on manipule que la façon dont on les manipule. C'est à dire que l'on dispose d'un nombre important de façons simples de transformer certaines données en d'autres, et les points cruciaux sont alors de:
+-Bien choisir la façon dont seront représentées les données traitées
 -Trouver les structures de données intermédiaires au cours du déroulement d'un algorithme.
 
-Si l'on sais exactement de quels donnés l'on part, et quels donnés on droit produire, il ne reste alors plus qu'à décrire les transformations nécessaire pour passer de l'une à l'autre. Par exemple, faire un programme de reconnaissance de caractère, c'est simplement transformer une image en une chaîne de caractère. Pour peut que l'on parvienne à réduire l'écart entre les structures de donnés considérés (par exemple une image, puis une liste de rectangles de pixels représentant des lignes, puis une liste de liste de rectangles de pixels représentant des mots) il devient très simple de décrire la transformation (on a réussi a réduire le problème a savoir découper les lignes, découper les mots, découper les lettres puis reconnaître une lettre).
+Si l'on sait exactement de quelles données l'on part, et quelles données on doit produire, il ne reste alors plus qu'à décrire les transformations nécessaires pour passer de l'une à l'autre. Par exemple, faire un programme de reconnaissance de caractères, c'est simplement transformer une image en une chaîne de caractères. Pour peu que l'on parvienne à réduire l'écart entre les structures de données considérées (par exemple une image, puis une liste de rectangles de pixels représentant des lignes, puis une liste de listes de rectangles de pixels représentant des mots) il devient très simple de décrire la transformation (on a réussi à réduire le problème à savoir découper les lignes, découper les mots, découper les lettres puis reconnaître une lettre).
 
-Si ce type de raisonnement peut conduire à du code catastrophique dans un langage objet, en haskell c'est très certainement l'une des routes les plus sur. Tout, dans le langage, s'adapte parfaitement à cette conduite, et particulièrement le système de types et de classes.
+Si ce type de raisonnement peut conduire à du code catastrophique dans un langage objet, en haskell c'est très certainement l'une des routes les plus sûres. Tout, dans le langage, s'adapte parfaitement à cette conduite, et particulièrement le système de types et de classes.
 
-En C++ un type représente un ensemble de fonctionnalités. En haskell un type n'est rien d'autre qu'un ensemble possible de valeur. On peut tout de fois préciser qu'un type peut être manipulé d'une certaine façon (ordonné, comparé, affiché...). On pourrait dire que deux éléments d'un type que l'on a construit peuvent être affiché, ou encore comparé, en le faisant instance d'une classe. Cela correspond a la surcharge de fonctions/opérateurs du C++ ; après avoir déclarer une structure `struct St;`, on peut surcharger l'opérateur de comparaison pour ce nouveau type par `bool operator < (St &a, St &b);`. Vient alors l'idée de ce que doit être quelque chose "d'affichable" ou de "comparable". C'est un type pour le quel on doit avoir certaines fonctions de définies. En java, il y à la notion d'interface, où l'on veut imposer l’existence de certaines méthodes. Malheureusement, on ne peut le faire que lors de la déclaration d'un type, et l'implémentation de cette interface est faite "à l'intérieur" du type. En haskell, pas de fonctions membres, mais des fonctions tout cours. Ce qui fait que n'importe quel type pourra devenir instance de n'importe quel classe (terme haskell désignant un jeu de fonctions) et à l'instant où vous le désirerais. Le sens d'une classe en haskell est donc plus proche de celle de la théorie des ensembles (une collection d'objets [ici de types] qui respectent certaines conditions [ici, pouvoir être comparé, affiché...]) ou si vous voulait vraiment une analogie en langage impératif, des interfaces du java. Ce n'est certainement pas celui des classes C++.
+En C++ un type représente un ensemble de fonctionnalités. En haskell un type n'est rien d'autre qu'un ensemble possible de valeurs. On peut toutefois préciser qu'un type peut être manipulé d'une certaine façon (ordonné, comparé, affiché...). On pourrait dire que deux éléments d'un type que l'on a construit peuvent être affichés, ou encore comparés, en le faisant instance d'une classe. Cela correspond à la surcharge de fonctions/opérateurs du C++ ; après avoir déclaré une structure `struct St;`, on peut surcharger l'opérateur de comparaison pour ce nouveau type par `bool operator < (St &a, St &b);`. Vient alors l'idée de ce que doit être quelque chose "d'affichable" ou de "comparable". C'est un type pour lequel on doit avoir certaines fonctions de définies. En java, il y a la notion d'interface, où l'on veut imposer l’existence de certaines méthodes. Malheureusement, on ne peut le faire que lors de la déclaration d'un type, et l'implémentation de cette interface est faite "à l'intérieur" du type. En haskell, pas de fonctions membres, mais des fonctions tout court. Ce qui fait que n'importe quel type pourra devenir instance de n'importe quelle classe (terme haskell désignant un jeu de fonctions) et à l'instant où vous le désirerez. Le sens d'une classe en haskell est donc plus proche de celle de la théorie des ensembles (une collection d'objets [ici de types] qui respectent certaines conditions [ici, pouvoir être comparé, affiché...]) ou si vous voulez vraiment une analogie en langage impératif, des interfaces du java. Ce n'est certainement pas celui des classes C++.
 
-Quand on prétend qu'un type est instance d'une classe, on doit fournir l'implémentation des fonctions de la classe, mais pas nécessairement toutes. Les classes fournissent souvent une implémentation des fonctions, souvent en terme récursif. Par exemple on pourrais définir a /= b à partir de == et a == b à partir de /=. De cette façon, il suffit de définir l'une des deux fonctions pour pouvoir immédiatement utiliser les deux opérateurs. (Le compilateur s'assurant que cela n'engendre pas de sur-coût en terme de performances).
+Quand on prétend qu'un type est instance d'une classe, on doit fournir l'implémentation des fonctions de la classe, mais pas nécessairement toutes. Les classes fournissent souvent une implémentation des fonctions, souvent en terme récursif. Par exemple on pourrait définir a /= b à partir de == et a == b à partir de /=. De cette façon, il suffit de définir l'une des deux fonctions pour pouvoir immédiatement utiliser les deux opérateurs. (Le compilateur s'assurant que cela n'engendre pas de sur-coût en terme de performances).
 
-Voici par exemple la classe Eq, décrivant deux objets pouvant être comparé :
+Voici par exemple la classe Eq, décrivant deux objets pouvant être comparés :
 ``` haskell
 class  Eq a  where
 class Eq a where
@@ -114,7 +114,7 @@ class Eq a where
     x /= y = not (x == y)
 ```
 
-On rend un type instance d'une classe de la façon suivante (exemple honteusement tirer de _Learn you haskell for a great good_ :
+On rend un type instance d'une classe de la façon suivante (exemple honteusement tiré de _Learn you haskell for a great good_ :
 ``` haskel
 data TrafficLight = Red | Yellow | Green
 
@@ -126,34 +126,34 @@ instance Eq TrafficLight where
 ```
 On définit l'égalité grâce au filtrage par motif, en définissant seulement l'opérateur ==.
 
-Bon, à vrais dire, pour les classes comme Eq (comparable) et Show (affichable), on peut laisser haskell s'en charger comme un grand :
+Bon, à vrai dire, pour les classes comme Eq (comparable) et Show (affichable), on peut laisser haskell s'en charger comme un grand :
 ``` haskell
 data TrafficLight = Red | Yellow | Green deriving (Show, Eq)
 ```
 
-En fait, quand on parleras de foncteurs, foncteurs applicatifs ou monades, on parleras de type qui sont instance respectivement de Functor (Prelude.Functor), de Applicative (Control.Applicative) et de Monad (Control.Monad).
+En fait, quand on parlera de foncteurs, foncteurs applicatifs ou monades, on parlera de types qui sont instance respectivement de Functor (Prelude.Functor), de Applicative (Control.Applicative) et de Monad (Control.Monad).
 
 ### Les foncteurs
 
-Les foncteurs (à nouveau, le terme est à prendre au sens e la théorie des catégories) constituent le point de départ vers les monades. Faisons un petit détour par les maths et définissons ce qu'est un foncteur (il n'est pas nécessaire de comprendre ce paragraphe pour la suite, c'est pour la culture).
+Les foncteurs (à nouveau, le terme est à prendre au sens de la théorie des catégories) constituent le point de départ vers les monades. Faisons un petit détour par les maths et définissons ce qu'est un foncteur (il n'est pas nécessaire de comprendre ce paragraphe pour la suite, c'est pour la culture).
 
-__La catégorie des types :___ Une catégorie $\mathcal{C}$ est une collection d'ensembles. Ici, on regarderas la collection de tous les types hasell possible. Un ensemble seras donc un type. Ses éléments seront les valeurs qui sont de ce type. Par exemple Int seras un semble et 1, 4, 6 sont des éléments de cette ensemble. Il n'y a que deux éléments dans l'ensemble Bool, et une infinité d'éléments pour Integer. Pour que ce soit une catégorie, il faut qu'étant donné deux ensembles de notre collection $A$ et $B$, il existes une ensemble d'applications de $A \to B$. Dans notre cas ce seras toute les _fonctions_ de type <i> A -> B </i>. On parle des "flèches de A vers B". Pour la culture, on note l'ensemble de ces applications $Hom_{\mathcal{C}}(A, B)$.
+__La catégorie des types :___ Une catégorie $\mathcal{C}$ est une collection d'ensembles. Ici, on regardera la collection de tous les types haskell possibles. Un ensemble sera donc un type. Ses éléments seront les valeurs qui sont de ce type. Par exemple Int sera un ensemble et 1, 4, 6 sont des éléments de cet ensemble. Il n'y a que deux éléments dans l'ensemble Bool, et une infinité d'éléments pour Integer. Pour que ce soit une catégorie, il faut qu'étant donné deux ensembles de notre collection $A$ et $B$, il existe un ensemble d'applications de $A \to B$. Dans notre cas ce sera toutes les _fonctions_ de type <i> A -> B </i>. On parle des "flèches de A vers B". Pour la culture, on note l'ensemble de ces applications $Hom_{\mathcal{C}}(A, B)$.
 
 Attention, pour que ce soit vraiment une catégorie, il faut quelques conditions sur ces flèches :
 
   1) Si $A$ est un élément de $\mathcal{C}$, alors il faut que l'identité soit une flèche. Dans notre cas, on veut que la fonction `id x = x` de type `A -> A` soit bien une fonction haskell. Ce qui est le cas, puisque je viens de vous donner le code haskell qui permet de la définir :)
 
-  2) Si $f: A \to B$ et $g : B \to C$ sont deux flèches (respectivement de $A$ dans $B$ et de $B$ dans $C$), alors la composé $g \circ f$ est une flèche de $A$ dans $C$. Dans le cas qui nous intéresse, cette règle est bien respectée car si `f` et `g` sont deux fonctions haskell, alors la composé est la fonction `\x -> g (f x)`, que l'on peut aussi écrire `f . g`.
+  2) Si $f: A \to B$ et $g : B \to C$ sont deux flèches (respectivement de $A$ dans $B$ et de $B$ dans $C$), alors la composée $g \circ f$ est une flèche de $A$ dans $C$. Dans le cas qui nous intéresse, cette règle est bien respectée car si `f` et `g` sont deux fonctions haskell, alors la composée est la fonction `\x -> g (f x)`, que l'on peut aussi écrire `f . g`.
 
-Donc, pour résumer : La collection de tous les types haskell est une catégorie. Si `a` et `b` sont deux types haskell, l'ensemble de toute les fonctions de `a -> b` sont appelés les flèches entre `a` et `b`.
+Donc, pour résumer : La collection de tous les types haskell est une catégorie. Si `a` et `b` sont deux types haskell, l'ensemble de toutes les fonctions de `a -> b` sont appelées les flèches entre `a` et `b`.
 
 __Les foncteurs (covariants) :__ Un foncteur $F$ d'une catégorie $\mathcal{C}$ vers une catégorie $\mathcal{D}$ est :
 
-  1) Pour chaque semble $A$ de $\mathcal{C}$, un ensemble de $\mathcal{D}$ qu'on noteras $F(A)$.
+  1) Pour chaque ensemble $A$ de $\mathcal{C}$, un ensemble de $\mathcal{D}$ qu'on notera $F(A)$.
 
-  2) Pour chaque flèche $f : A \to B$ entre des ensembles de $\mathcal{C}$, une flèche $F(A) \to F(B)$ qu'on noteras $F(f)$.
+  2) Pour chaque flèche $f : A \to B$ entre des ensembles de $\mathcal{C}$, une flèche $F(A) \to F(B)$ qu'on notera $F(f)$.
 
-  3) Il faut que $F(g \circ f) = F (g) \circ F(f)$ et que $F(id) = id$. C'est à dire que composer des flèches avant transformation est la même chose que les composer après, et l'identité $id: A \to A$ (flèche qui ne fait rien) est bien envoyer sur l'identité $id: F(A) -> F(A)$.
+  3) Il faut que $F(g \circ f) = F (g) \circ F(f)$ et que $F(id) = id$. C'est à dire que composer des flèches avant transformation est la même chose que les composer après, et l'identité $id: A \to A$ (flèche qui ne fait rien) est bien envoyée sur l'identité $id: F(A) -> F(A)$.
 
 Un foncteur est donc une façon de transformer une catégorie $\mathcal{C}$ en une partie (sous-catégorie) de $\mathcal{D}$.
 
@@ -161,13 +161,13 @@ __Point culture (pour les curieux) :__ Les foncteurs contravariants sont simplem
 
 Ici, ce qui nous intéresse sont les foncteurs de $\mathcal{C}$ dans $\mathcal{C}$ (on dit des endofoncteurs). À partir de maintenant, on ne considère plus que la catégorie $\mathcal{T}$ des types haskell. Un foncteur `Fonc`, en haskell, est un foncteur de $\mathcal{T}$ dans $\mathcal{T}$. C'est à dire :
 
-  1) Une façon à tout type `a` d'associer un type `Fonc a`. Ainsi `Fonc` est un constructeur de type, par exemple `Liste` ou `Arbre` des exemples précédents. C'est peut-être le bon moment d'aller feuilleter quelques lien sur les constructeurs de type et leur "kind". Disons simplement qu'un type comme int ou bool est de kind `*` mais que Liste et Arbre sont de kind `* -> *`. Cela signifit que ces deux dernier mangent un type `T` et fabrique des nouveaux types `Liste T` et `Arbre T`. Liste n'est donc pas un type, mais un constructeur de type.
+  1) Une façon à tout type `a` d'associer un type `Fonc a`.. Ainsi `Fonc` est un constructeur de type, par exemple `Liste` ou `Arbre` des exemples précédents. C'est peut-être le bon moment d'aller feuilleter quelques liens sur les constructeurs de type et leur "kind". Disons simplement qu'un type comme int ou bool est de kind `*` mais que Liste et Arbre sont de kind `* -> *`. Cela signifie que ces deux derniers mangent un type `T` et fabrique des nouveaux types `Liste T` et `Arbre T`. Liste n'est donc pas un type, mais un constructeur de type.
 
   2) Une façon à toute fonction `f :: a -> b` d'associer une fonction `f' :: Fonc a -> Fonc b`
 
   3) Cette façon de faire doit transformer l'identité `(\x -> x) :: a -> a` en l'identité `(\x -> x) :: Fonc a -> Fonc a`
 
-  4) Cette façon de faire doit passer à la composition, c'est à dire que si l'on transforme `f :: a -> b` en `f' :: Fonc a -> Fonc b` et `g :: b -> c` en `g' :: Fonc b -> Fonc c`, alors ` g . f ` seras transformé en `g' . f'`.
+  4) Cette façon de faire doit passer à la composition, c'est à dire que si l'on transforme `f :: a -> b` en `f' :: Fonc a -> Fonc b` et `g :: b -> c` en `g' :: Fonc b -> Fonc c`, alors ` g . f ` sera transformé en `g' . f'`.
 
 Pour qu'un constructeur de type `Fonc` soit un foncteur, on le fait instance de la classe Functor définie comme suit :
 ``` haskell
@@ -177,7 +177,7 @@ class  Functor f  where
 
 Remarquez que l'on peut lire `fmap :: (a -> b) -> (f a -> f b)` ce qui signifie : fmap(fonctorial mapping) prend une fonction de type `a -> b` et la transforme en une fonction de type `f a -> f b`. On a donc bien une transformation d'une flèche de a vers b en une flèche de $f a$ vers $f b$. Si l'on a donc un constructeur de type qui est instance de `Functor`, on a bien un endofoncteur de la catégorie des types. Maintenant que nous avons le sentiment que toutes nos considérations théoriques nous ont apporté une compréhension profonde du sujet, nous allons pouvoir les oublier et passer à la pratique.
 
-A quoi sert un foncteur : Un constructeur de type fonctoriel, c'est un constructeur de type où l'on sauras maper des fonctions. Si notre type Liste devient instance de `Functor`, et que l'on a un `Liste Int`, on peut construire rapidement une liste de tous ces nombres représenté par des chaines de caractères. Il suffit de disposer d'une fonction `Int -> String`. Haskell nous en fournis une, c'est `show`. Alors, on n'a plus qu'a appliquer cette fonction sur chacun des éléments de la liste par `map show liste`.
+A quoi sert un foncteur : Un constructeur de type fonctoriel, c'est un constructeur de type où l'on saura mapper des fonctions. Si notre type Liste devient instance de `Functor`, et que l'on a un `Liste Int`, on peut construire rapidement une liste de tous ces nombres représentés par des chaînes de caractères. Il suffit de disposer d'une fonction `Int -> String`. Haskell nous en fournit une, c'est `show`. Alors, on n'a plus qu'a appliquer cette fonction sur chacun des éléments de la liste par `map show liste`.
 
 Regardons comment rendre Liste instance de Functor :
 ``` haskell
@@ -193,7 +193,7 @@ listeEstPositif = fmap estPositif listeEntiers
 -- listeEstPositif = Cons True (Cons False (Cons False (Cons True Vide)))
 ```
 
-Si vous réfléchissez bien, ça ressemble beaucoup à ce que vous faites à chaque fois que vous appliquez un traitement aux éléments d'un container ; vous parcourez une liste, et vous appliquez votre procédure à chaque élément. L'avantage d'avoir une unique fonction fmap implémenté pour chaque type, c'est que si vous décidez de modifier votre container, vous n'aurez que très peut de changement à faire. Il suffiras de rendre le nouveau container instance de Functor, alors qu'en C++, si vous utilisiez auparavant des containers de la STL, il vous faudra vous assurer que votre nouvelle structure fournie elle aussi des littérateurs, ce qui peut être assez lourd à fournir, voir impossible si vous n'êtes pas auteur de la classe.
+Si vous réfléchissez bien, ça ressemble beaucoup à ce que vous faites à chaque fois que vous appliquez un traitement aux éléments d'un container ; vous parcourez une liste, et vous appliquez votre procédure à chaque élément. L'avantage d'avoir une unique fonction fmap implémentée pour chaque type, c'est que si vous décidez de modifier votre container, vous n'aurez que très peu de changements à faire. Il suffira de rendre le nouveau container instance de Functor, alors qu'en C++, si vous utilisiez auparavant des containers de la STL, il vous faudra vous assurer que votre nouvelle structure fournie elle aussi des itérateurs, ce qui peut être assez lourd à fournir, voire impossible si vous n'êtes pas auteur de la classe.
 
 Parmi les instances de Functor il y a donc les listes (les vrais listes []), mais aussi Maybe. On peut donc utiliser Maybe pour utiliser des valeurs dans un contexte. Par exemple :
 ``` haskell
@@ -208,9 +208,9 @@ doSomething n = (n + 32) * 5
 res = fmap doSomething (divideBy 3 7)
 ```
 
-Il est très important de bien saisir l’intérêt des foncteurs (qui n'est pas cantonné aux langages fonctionnels), et leur fonctionnement pour la suite. La dernière partie ne traiteras que de leurs spécialisations : les foncteurs applicatifs et les monades.
+Il est très important de bien saisir l’intérêt des foncteurs (qui n'est pas cantonné aux langages fonctionnels), et leur fonctionnement pour la suite. La dernière partie ne traitera que de leurs spécialisations : les foncteurs applicatifs et les monades.
 
-___Point culture :___ Et si l'on veux un foncteur contravariant en haskell? On peut prendre par exemple le constructeur de type `type Func a = a -> Int` et la fonction `map :: (a -> b) -> (b -> Int) -> (a -> Int) ; map f fa = fb . f`. On construit bien une fonction de type `a -> Int` à partir d'une fonction de type `b -> Int`. On a donc "inversé les flèches", puisque l'on part de "a -> b" pour obtenir du "Func b -> Func a".</i>
+___Point culture :___ Et si l'on veut un foncteur contravariant en haskell? On peut prendre par exemple le constructeur de type `type Func a = a -> Int` et la fonction `map :: (a -> b) -> (b -> Int) -> (a -> Int) ; map f fa = fb . f`. On construit bien une fonction de type `a -> Int` à partir d'une fonction de type `b -> Int`. On a donc "inversé les flèches", puisque l'on part de "a -> b" pour obtenir du "Func b -> Func a".</i>
 
 
 ### Références :

--- a/_posts/haskell-pure-3/2013-05-01-haskell-pure-3.md
+++ b/_posts/haskell-pure-3/2013-05-01-haskell-pure-3.md
@@ -1,15 +1,15 @@
 ---
 layout: post
 title: Le Haskell, un langage au label pure. Troisième partie.
-description: Inroduction à haskell (partie 2). On discute
-  foncteurs aplicatifs, et monades.
+description: Introduction à haskell (partie 3). On discute
+  foncteurs applicatifs, et monades.
 author: Jérémy Cochoy
 date: 2013-05-01 + 0100
 categories: programming haskell language software
 lang: fr
 ...
 
-Et voici la troisième et dernière partie de notre découverte de ce joli langage. Au programme : des super foncteurs. D'abord des foncteurs applicatifs, puis des monades! Si vous rêviez de savoir pourquoi tant de gens s’enflamment devant ce langage, il est peut-être venue l'heure de la révélation.
+Et voici la troisième et dernière partie de notre découverte de ce joli langage. Au programme : des super foncteurs. D'abord des foncteurs applicatifs, puis des monades! Si vous rêviez de savoir pourquoi tant de gens s’enflamment devant ce langage, il est peut-être venu l'heure de la révélation.
 
 La [première partie est ici](http://zenol.fr/site/blog/posts/haskell-pure-1/fr.htm "Le Haskell, un langage au label pure. Première partie."), [la seconde là](http://zenol.fr/site/blog/posts/haskell-pure-2/fr.htm "Le Haskell, un langage au label pure. Seconde partie.").
 
@@ -22,11 +22,11 @@ class (Functor f) => Applicative f where
    (<*>) :: f (a -> b) -> f a -> f b
 ```
 
-Avec un type fonctoriel Fonc, on pouvais :
+Avec un type fonctoriel Fonc, on pouvait :
   * Prendre un élément de type `c` et le transformer en `Fonc c`, c'est à dire le "placer dans un contexte minimal".
   * Prendre une fonction de type `a->b` et la transformer en une fonction de type `Fonc a -> Fonc b` grâce à `fmap`.
 
-Grace à un foncteur applicatif, on peut :
+Grâce à un foncteur applicatif, on peut :
   * Prendre un élément de type <i>c</i> et le transformer en type `Fonc c`, cela se fait grâce à la fonction `pure :: (Applicative f) => c -> f c`.
   * Prendre une fonction dans un foncteur (ie un élément de type `Fonc (a->b)`) et l'appliquer à un élément de type `Fonc a` pour produire un `Fonc b`. L'opérateur permettant une telle chose est noté `<*> :: (Applicative f) => f (a -> b) -> f a -> f b`.
 
@@ -38,7 +38,7 @@ instance Functor Fonc where
 
 C'est à dire : Prenez f une fonction de type `a -> b`, alors vous savez comment l'appliquer sur un `Fonc a`. Il suffit de la "placer" elle aussi dans un foncteur, pour se retrouver avec une "fonction dans un contexte" de type `Fonc (a->b)` à appliquer sur un "élément dans un contexte" de type `F a`.
 
-C'est donc pour cela que l'on impose à tout foncteur applicatif d'être d'abord une instance de `Functor`, et que vous avez la contraire `"Functor f"` dans la définition de la classe `Applicative`.
+C'est donc pour cela que l'on impose à tout foncteur applicatif d'être d'abord une instance de `Functor`, et que vous avez la contrainte `"Functor f"` dans la définition de la classe `Applicative`.
 
 ### On se prépare au grand saut avec `Maybe`
 
@@ -52,7 +52,7 @@ instance Applicative Maybe where
 
 La méthode `pure` prend un `truc :: a` et le place dans un `Maybe a` par `Just truc`. C'est la façon la plus intuitive de placer notre `truc` dans un `Maybe`, sans perdre d'information. L'opérateur `<*>` se contente lui de récupérer la fonction à sa gauche, la valeur à sa droite, d'effectuer le calcul (l'application de f à x) puis de placer le résultat dans un contexte minimal en utilisant le constructeur `Just`. La dernière ligne s’occupe des cas où il manque la fonction, l'argument, ou bien les deux. Dans ces trois cas, on ne peut effectuer le calcul, et l'on ne peut donc pas produire de résultat.
 
-Comme dit plus haut, si l'on vais une fonction qui prend la racine carré (`sqrt :: Int`) d'un entier, et "peut-être un nombre" (un `v :: Maybe Int`), on pouvais mapper notre fonction avec la ligne `fmap sqrt v`. Avec un foncteur applicatif, on peut aussi écrire :
+Comme dit plus haut, si l'on a une fonction qui prend la racine carrée (`sqrt :: Int`) d'un entier, et "peut-être un nombre" (un `v :: Maybe Int`), on pouvait mapper notre fonction avec la ligne `fmap sqrt v`. Avec un foncteur applicatif, on peut aussi écrire :
 ``` haskell
 resultat  = (pure sqrt) <*> v
 ```
@@ -62,7 +62,7 @@ Mais alors, quel est l’intérêt des foncteurs applicatifs? Un premier exemple
 --Ici, v1, v2 et v3 sont de type Maybe Int.
 --Si vous voulez savoir d'où il viennent, disons que ce sont le résultat
 --de la lecture d'une chaine de caractère et de tentative de conversion de
---la chaine en nombres. Si c'était possible, alors on a des valeurs. Sinon, on auras "Nothing".
+--la chaine en nombres. Si c'était possible, alors on a des valeurs. Sinon, on aura "Nothing".
 
 --On a une superbe fonction :
 deepThought :: Int -> Int -> Int -> Answer
@@ -72,7 +72,7 @@ deepThought :: Int -> Int -> Int -> Answer
 premiereApplication :: Maybe (Int->Int->Answer)
 premiereApplication = fmap deepThought v1
 
---Maintenant, on est bloquer, on ne sais pas appliquer
+--Maintenant, on est bloqué, on ne sait pas appliquer
 -- une fonction qui se trouve dans un maybe...
 --... à moins d'utiliser <*> :)
 secondeApplication :: Maybe (Int -> Answer)
@@ -104,7 +104,7 @@ instance Applicative [] where
     fs <*> xs = [f x | f <- fs, x <- xs]
 ```
 
-Cela donne une façon très facile d'effectuer de nombreux calculs simultanément ; vous disposez d'un ensemble de valeurs, et d'un ensemble de fonctions. Vous voulez connaître TOUS les résultats possible. Il suffit alors d'appliquer la liste des fonctions sur la liste des valeurs avec l'opérateur `<*>`. Un exemple, en partie tiré de_Learn You Haskell for Great Good_ est le problème du parcoure d'un cavalier. Un cavalier est situé sur une case d'un échiquier infini, et vous voulez connaître toute les positions où il peut se trouver après 5 coups. Il suffit décrire une fonction par déplacement possible, puis de construire une liste de ces fonctions,  disons `[u1, u2, l1, l2, r1, r2, d1, d2]`. On applique cette liste à la position d'origine placée dans un contexte : `[(x, y)]` (ou encore `pure (x, y)`). La solution est donné par l'application répété de notre liste de fonction, comme le montre le code suivant.
+Cela donne une façon très facile d'effectuer de nombreux calculs simultanément ; vous disposez d'un ensemble de valeurs, et d'un ensemble de fonctions. Vous voulez connaître TOUS les résultats possible. Il suffit alors d'appliquer la liste des fonctions sur la liste des valeurs avec l'opérateur `<*>`. Un exemple, en partie tiré de _Learn You Haskell for Great Good_ est le problème du parcours d'un cavalier. Un cavalier est situé sur une case d'un échiquier infini, et vous voulez connaître toutes les positions où il peut se trouver après 5 coups. Il suffit d'écrire une fonction par déplacement possible, puis de construire une liste de ces fonctions,  disons `[u1, u2, l1, l2, r1, r2, d1, d2]`. On applique cette liste à la position d'origine placée dans un contexte : `[(x, y)]` (ou encore `pure (x, y)`). La solution est donnée par l'application répétée de notre liste de fonction, comme le montre le code suivant.
 
 ``` haskell
 u1 (l, c) = (l+2,c+1)
@@ -126,9 +126,9 @@ solution (l, c) = etapeSuivante . etapeSuivante . etapeSuivante . etapeSuivante 
 
 ### En apnée : le foncteur `(->) r` !
 
-On les avais cacher lors de la discussion des foncteurs, car ils sont difficile à cerné. Leur intérêt n'est pas évident au premier abord et leur construction est quelque peu... surprenante. Mais puisqu'ils sont utile comme foncteur applicatif, parlons en! Si la partie la plus abstraite vous échappe, aucune raison de vous inquiéter, l'idée est de survoler les notions pour avoir un aperçu, éveiller la curiosité et inciter à lire des livres/articles qui expliquent en détaille ce qui n'est ici que mentionner. Si tout cela vous intéresse, sautez à la section "Foncteurs applicatifs" de Learn You Haskell for Great Good!
+On les avait cachés lors de la discussion des foncteurs, car ils sont difficiles à cerner. Leur intérêt n'est pas évident au premier abord et leur construction est quelque peu... surprenante. Mais puisqu'ils sont utiles comme foncteur applicatif, parlons-en! Si la partie la plus abstraite vous échappe, aucune raison de vous inquiéter, l'idée est de survoler les notions pour avoir un aperçu, éveiller la curiosité et inciter à lire des livres/articles qui expliquent en détail ce qui n'est ici que mentionné. Si tout cela vous intéresse, sautez à la section "Foncteurs applicatifs" de Learn You Haskell for Great Good!
 
-L'opérateur `->` est un constructeur de type, à deux arguments. Vous lui donnez deux types, `a` et `b`, et il vous construiras le type "prend du a et retourne du b". On peut donc écrire `f :: a -> b` ou encore ` f :: (->) a b`. Que signifie alors `(->) r` ? On parle d'un constructeur de type à un argument qui, si vous lui donnez un type `a`, désigneras alors les fonctions de type `a -> r`. Si `r` désigne un type, on peut alors faire de `(->) r` une instance de `Functor` où mapper une fonction `f` de type `a->b` sur une fonction `g` de type `a -> r` signifie appliquer `f` au résultat de l'évaluation de la fonction `g`. Plus précisément :
+L'opérateur `->` est un constructeur de type, à deux arguments. Vous lui donnez deux types, `a` et `b`, et il vous construiras le type "prend du a et retourne du b". On peut donc écrire `f :: a -> b` ou encore ` f :: (->) a b`. Que signifie alors `(->) r` ? On parle d'un constructeur de type à un argument qui, si vous lui donnez un type `a`, désignera alors les fonctions de type `a -> r`. Si `r` désigne un type, on peut alors faire de `(->) r` une instance de `Functor` où mapper une fonction `f` de type `a->b` sur une fonction `g` de type `a -> r` signifie appliquer `f` au résultat de l'évaluation de la fonction `g`. Plus précisément :
 ``` haskell
 instance Functor ((->) r) where
     fmap f g = (\x -> f (g x))
@@ -138,9 +138,9 @@ On peut se demander l’intérêt, puisque `(fmap f g) 42` se simplifie en `f . 
 
 Un exemple commenté :
 ``` haskell
---Notre type "paramètre". On aurais pu construire une sorte de grosse structure
+--Notre type "paramètre". On aurait pu construire une sorte de grosse structure
 -- avec diverses informations.
---Dans cette exemple, on se contenteras d'un nombre.
+--Dans cet exemple, on se contentera d'un nombre.
 type Param = Int
 
 unEntier :: Param -> Int
@@ -156,12 +156,12 @@ somme = pure (+) <$> unEntier <*> unAutreEntier
 affichage = uneFonction <*> somme
 
 --Vaut 94 :
-evaluationDansUnCOntexte = affichage 42
+evaluationDansUnContexte = affichage 42
 ```
 
 ### Quelques règles que nul ne doit ignorer
 
-Comme on dit, `dura lex, sed lex`. Les foncteurs devaient respecter certaines règles, et il en est de même des foncteurs applicatifs. Une fois habitué aux foncteurs applicatifs, ces règles semblent découler du bon sens. Ce sont des invariants que DOIVENT respecter vos instances d'`Applicative`. Si vous ne les respectez pas, c'est que ce que vous voulez faire n'est pas un foncteur applicatif, et n'a donc aucune raison d’être instance d'`Applicative`.
+Comme on dit, `dura lex, sed lex`. Les foncteurs devaient respecter certaines règles, et il en est de même des foncteurs applicatifs. Une fois habitués aux foncteurs applicatifs, ces règles semblent découler du bon sens. Ce sont des invariants que DOIVENT respecter vos instances d'`Applicative`. Si vous ne les respectez pas, c'est que ce que vous voulez faire n'est pas un foncteur applicatif, et n'a donc aucune raison d’être instance d'`Applicative`.
 
 Sans trop rentrer dans les détails, les voici, brièvement commentés :
 ``` haskell
@@ -192,7 +192,7 @@ u <*> pure y = pure ($ y) <*> u
 
 ## Monades
 
-Les monades, c'est le cran au dessus. On ne veut plus seulement mapper des fonctions `f: a -> b` à l'intérieur d'un `Fonc a`, ni seulement évaluer des fonctions `Fonc (a -> b)` dans un contexte `F a`. Maintenant, on dispose de fonctions qui travaillent sur une valeur, et produisent un résultat dans un contexte. Des fonctions de type `f :: a -> Fonc b`. Si l'on essayais de les mapper comme des foncteurs sur un `Fonc a`, on se retrouverais avec du `Fonc (Fonc b)`, ce qui n'est pas du tout ce que l'on veut. Il nous faut donc une fonction capable de recoller ces "Fonc Fonc" en "Fonc". C'est ce que fournisse les monades.
+Les monades, c'est le cran au dessus. On ne veut plus seulement mapper des fonctions `f: a -> b` à l'intérieur d'un `Fonc a`, ni seulement évaluer des fonctions `Fonc (a -> b)` dans un contexte `F a`. Maintenant, on dispose de fonctions qui travaillent sur une valeur, et produisent un résultat dans un contexte. Des fonctions de type `f :: a -> Fonc b`. Si l'on essayait de les mapper comme des foncteurs sur un `Fonc a`, on se retrouverait avec du `Fonc (Fonc b)`, ce qui n'est pas du tout ce que l'on veut. Il nous faut donc une fonction capable de recoller ces "Fonc Fonc" en "Fonc". C'est ce que fournissent les monades.
 
 Tout de suite, la classe monade :
 ``` haskell
@@ -200,10 +200,10 @@ class Monad m where
   (>>=) :: m a -> (a -> m b) -> m b -- On l’appelle aussi "bind"
   (>>) :: m a -> m b -> m b -- C'est une sorte d'opérateur de concaténation.
 -- >> Ignore le premier argument et renvoi la valeur du second.
--- On vera plus tard qu'en fait, c'est extrêmement utile, avec la monade IO.
+-- On verra plus tard qu'en fait, c'est extrêmement utile, avec la monade IO.
   return :: a -> m a -- C'est notre bon vieux pure, sous un autre nom.
-  fail :: String -> m a -- On ne l'utiliseras pas, et on en parleras pas.
--- Sachez toute fois que ca renvoi moralement un "contexte sans information".
+  fail :: String -> m a -- On ne l'utilisera pas, et on n'en parlera pas.
+-- Sachez toutefois que ça renvoie moralement un "contexte sans information".
 -- Par exemple une liste vide, un Nothing, etc.
 ```
 
@@ -218,11 +218,11 @@ instance Monade Fonc where
 -- On donne mf à manger a la grosse fonction de droite. La grosse fonction de droite récupère la fonction f, la transforme en une f' par return.f. On donne donc la valeur v contenue dans mv à manger a la fonction f' grâce à >>=.
 ```
 
-Bon, si vous avez suivi jusque là, soit vous connaissez déjà le haskell, soit vous êtes des sur-hommes (ou des matheux, auquel cas je ne peux plus rien pour vous). Voyons en pratique ce qu'apportent les monades, et pourquoi est-ce que bien utilisé, elles offres une nouvelle façon de résoudre certains problèmes bien connu du monde impératif.
+Bon, si vous avez suivi jusque là, soit vous connaissez déjà le haskell, soit vous êtes des sur-hommes (ou des matheux, auquel cas je ne peux plus rien pour vous). Voyons en pratique ce qu'apportent les monades, et pourquoi est-ce que bien utilisées, elles offrent une nouvelle façon de résoudre certains problèmes bien connus du monde impératif.
 
 ### Être ou ne pas être?
 
-Dans un "vrai" programme, on n'a pas toujours une valeur a retourner pour une fonction. Que faire si l'on demande le premier élément d'une liste vide? Et si jamais on veut convertir une chaine en un nombre, qui par malheur contient le prénom de votre animal de compagnie? En bref, comment gérer une erreur correspondant à l’absence d'un résultat?
+Dans un "vrai" programme, on n'a pas toujours une valeur à retourner pour une fonction. Que faire si l'on demande le premier élément d'une liste vide? Et si jamais on veut convertir une chaine en un nombre, qui par malheur contient le prénom de votre animal de compagnie? En bref, comment gérer une erreur correspondant à l’absence d'un résultat?
 
 La réponse est la monade maybe. Commençons par des fonctions qui renvoient peut-être une valeur :
 ``` haskell
@@ -238,25 +238,25 @@ maybeRange False = Nothing
 maybeRange True = (23, 42)
 ```
 
-On voudrais maintenant récupérer le premier élément de la liste pour les valeur donné par maybeRange, si la liste existe, bien sure. C'est la que les monades interviennent! Grâce au monades, on peut composer les deux fonctions, bien qu'un `Maybe [Int]` ne soit pas un `[Int]`.
+On voudrais maintenant récupérer le premier élément de la liste pour les valeurs données par maybeRange, si la liste existe, bien sûr. C'est là que les monades interviennent! Grâce aux monades, on peut composer les deux fonctions, bien qu'un `Maybe [Int]` ne soit pas un `[Int]`.
 ``` haskell
 resultat :: Maybe Int
 resultat choice = maybeRange choice >>= maybeList >>= maybeHead
 ```
 
-Si l'une des étapes ne produit pas de résultat (un `Nothing`), alors l’absence de résultat seras propagé et on obtiendras un `Nothing`.
+Si l'une des étapes ne produit pas de résultat (un `Nothing`), alors l’absence de résultat sera propagée et on obtiendra un `Nothing`.
 
-Cette méthode a de nombreux avantages par rapport aux deux vielles solutions bien connues :
+Cette méthode a de nombreux avantages par rapport aux deux vieilles solutions bien connues :
 1) Le "code d'erreur", c'est à dire placer nullptr quand on pointeur n'existe pas, ou encore "-1" ou 0 pour signaler une erreur. L'inconvénient de cette méthode est d'obliger le développeur à vérifier chacune des valeurs de retour avec un if, généralement pour sortir de la fonction, souvent en retournant un nouveau code d’erreur pour signaler que le résultat produit n'est pas "vraiment" un résultat, mais une absence de résultat.
 
-L'utilisation de la monade Maybe permet d'éviter ces testes répété. Si une seul des fonctions ne peut pas fournir de résultat, alors les applications suivantes seront toute ignoré et, bien entendu, ces fonctions ne seront pas évaluées, donc pas de coût en temps de calcul.
+L'utilisation de la monade Maybe permet d'éviter ces tests répétés. Si une seule des fonctions ne peut pas fournir de résultat, alors les applications suivantes seront toutes ignorées et, bien entendu, ces fonctions ne seront pas évaluées, donc pas de coût en temps de calcul.
 
-2) Les exceptions. Cela consiste à interrompre l'exécution normale du programme pour remonter a travers toute la pile d'appels, en espérant que quelqu'un seras assez gentil pour s'occuper de cette erreur. Cela a un coût en terme de performances, et doit être réserver pour les évènements exceptionnels. L'impossibilité de produire un résultat est rarement exceptionnel, c'est plutôt chose commune.
+2) Les exceptions. Cela consiste à interrompre l'exécution normale du programme pour remonter à travers toute la pile d'appels, en espérant que quelqu'un sera assez gentil pour s'occuper de cette erreur. Cela a un coût en terme de performances, et doit être réservé pour les évènements exceptionnels. L'impossibilité de produire un résultat est rarement exceptionnel, c'est plutôt chose commune.
 
-Le chaînage de monade Maybe a l'avantage de ne pas déclencher un erreurs qui pourrait se perdre et aller jusqu'à interrompre le programme. Que les valeurs soient présente ou non, le comportement est toujours "simple" à prédire. Et plus un code est simple, moins il y a de risque qu'une erreurs s'introduisse à l'insu du développeur.
+Le chaînage de monade Maybe a l'avantage de ne pas déclencher une erreur qui pourrait se perdre et aller jusqu'à interrompre le programme. Que les valeurs soient présentes ou non, le comportement est toujours "simple" à prédire. Et plus un code est simple, moins il y a de risque qu'une erreur s'introduise à l'insu du développeur.
 
 
-En règle générale, dès que le résultat peut ne pas être fournit, vous devriez utiliser la monade Maybe. Si parfois une certaine fonction f que vous voulez chaîner produit toujours un résultat, alors vous pouvez la placer au milieu d'une chaine de `>>=` en écrivant `return.f`. Vous pouvez aussi une bonne vielle `fmap`, car toute les monades sont des foncteurs applicatifs, donc des foncteurs.
+En règle générale, dès que le résultat peut ne pas être fourni, vous devriez utiliser la monade Maybe. Si parfois une certaine fonction f que vous voulez chaîner produit toujours un résultat, alors vous pouvez la placer au milieu d'une chaine de `>>=` en écrivant `return.f`. Vous pouvez aussi une bonne vieille `fmap`, car toutes les monades sont des foncteurs applicatifs, donc des foncteurs.
 
 Nb : Peut-être avez vous besoin de conserver une information sur l'origine de l'erreur. Ceci est possible grâce à la monade `Either a` (souvent on utilise `Either String` pour stocker un message).
 
@@ -271,9 +271,9 @@ instance Monad Maybe where
 
 ### Un calcul pas très déterministe
 
-Nous avions vu comment les listes comme foncteurs applicatifs permettent de résoudre élégamment la question du déplacement d'un cavalier. Mais dans un échiquier fini, on ne savais pas trop comment gérer les bords.
+Nous avions vu comment les listes comme foncteurs applicatifs permettent de résoudre élégamment la question du déplacement d'un cavalier. Mais dans un échiquier fini, on ne savait pas trop comment gérer les bords.
 
-Les listes, vu comme monade, nous permettent de combiner des fonctions de type `a -> [b]`. L'idée est que vous disposez de diverse fonctions qui prennent une valeur, et produise divers résultats possible. Vous voulez alors appliquer des fonctions sur chacun de ces résultats. On peut donc parler de calcul non-déterministe : une valeur donne plusieurs résultats possible.
+Les listes, vu comme monade, nous permettent de combiner des fonctions de type `a -> [b]`. L'idée est que vous disposez de diverses fonctions qui prennent une valeur, et produisent divers résultats possibles. Vous voulez alors appliquer des fonctions sur chacun de ces résultats. On peut donc parler de calcul non-déterministe : une valeur donne plusieurs résultats possible.
 
 On peut donc réaliser un remake du cavalier, en se servant de ce calcul non déterministe, puisqu'à partir d'une position, on a diverses positions possibles
 ``` haskell
@@ -281,10 +281,10 @@ On peut donc réaliser un remake du cavalier, en se servant de ce calcul non dé
 -- histoire de rappeler que les types sont
 -- aussi là pour fournir des informations sémantiques.
 type Ligne = Int
-type Collone = Int
-type Position = (Ligne, Collone)
+type Colonne = Int
+type Position = (Ligne, Colonne)
 
---Fonction utilisé pour ne garder que les positions dans l'échiquier
+--Fonction utilisée pour ne garder que les positions dans l'échiquier
 dansLechiquier :: Position -> Bool
 dansLechiquier (l, c) = l `elem` [1..8] && c `elem` [1..8]
 
@@ -299,10 +299,10 @@ resultat = return (4, 5) >>= deplacerCavalier >>= deplacerCavalier >>= deplacerC
 ```
 
 
-En fait, une autre façon de faire serai de mapper la fonction `deplacerCavalier` dans la liste de positions, produisant un `[[Position]]`, puis d'appeler `concat` sur cette liste, la recollant en une `[Position]`. C'est d'ailleurs de cette façon qu'est implémenté l'opérateur `>>=` !
+En fait, une autre façon de faire serait de mapper la fonction `deplacerCavalier` dans la liste de positions, produisant un `[[Position]]`, puis d'appeler `concat` sur cette liste, la recollant en une `[Position]`. C'est d'ailleurs de cette façon qu'est implémenté l'opérateur `>>=` !
 
-L'utilisation des listes sous leur forme de monade n'est pas limité à cette exemple. Je peux mentionner un second cas qui vous paraîtras peut-être plus concret. Disons que vous voulez enregistrer une image, et que vous disposez d'une fonction qui vous donne les couleurs r, g, b, a sous la forme d'une liste de nombres, c'est à dire `getPixel (x, y) :: [Word8]` (Word8 est un nombre codé sur 8 bits). Sachant que pour enregistrer l'image, vous devez fournir un tableau, qui peut être très facilement construit à partir de la liste des valeurs qu'il vas contenir. (Le compilateur est très malins, et le programme compilé ne s’amusera pas à produire une liste, la construire en mémoire, puis la placer dans le tableau. Pas d'inquiétude, le compilateur est très douer à ce niveau.)
-La monade `[]` permet d'écrire en une ligne, de façon très élégante, la création d'un tableau où les valeurs sont bien la succession des valeurs de `getPixel` calculé à chaque coordonné. Bien sur, on aurais pu utiliser `concat` et `map`, mais c'est justement ce que fait l'opérateur `>>=`. Tout ça pour dire que les listes vue comme monade ne sont pas un gadget, mais bien un outil utile à l'implémentation d'applications de la "vie de tout les jouers".
+L'utilisation des listes sous leur forme de monade n'est pas limitée à cet exemple. Je peux mentionner un second cas qui vous paraîtra peut-être plus concret. Disons que vous voulez enregistrer une image, et que vous disposez d'une fonction qui vous donne les couleurs r, g, b, a sous la forme d'une liste de nombres, c'est à dire `getPixel (x, y) :: [Word8]` (Word8 est un nombre codé sur 8 bits). Sachant que pour enregistrer l'image, vous devez fournir un tableau, qui peut être très facilement construit à partir de la liste des valeurs qu'il vas contenir. (Le compilateur est très malins, et le programme compilé ne s’amusera pas à produire une liste, la construire en mémoire, puis la placer dans le tableau. Pas d’inquiétude, le compilateur est très doué à ce niveau.)
+La monade `[]` permet d'écrire en une ligne, de façon très élégante, la création d'un tableau où les valeurs sont bien la succession des valeurs de `getPixel` calculées à chaque coordonnée. Bien sûr, on aurait pu utiliser `concat` et `map`, mais c'est justement ce que fait l'opérateur `>>=`. Tout ça pour dire que les listes vues comme monade ne sont pas un gadget, mais bien un outil utile à l'implémentation d'applications de la "vie de tous les jours".
 
 Voici la définition de l'instance pour les curieux :
 ``` haskell
@@ -315,7 +315,7 @@ instance Monad [] where
 ### Dou? Doo? Do, c'est le goût!
 
 La notation do est une sorte de super sucre syntaxique. Seulement, les monades sont tellement amère que vous aurez vraiment besoin de ce sucre, je vous l'assure.
-La notation do permet décrire facilement le chaînage d'actions, et le fait de récupérer des valeurs dans un contexte.
+La notation do permet d'écrire facilement le chaînage d'actions, et le fait de récupérer des valeurs dans un contexte.
 
 Considérons l'exemple suivant tiré de Learn You Haskell for Great Good (Non, je ne suis pas encore sponsorisé par eux.) :
 ``` haskell
@@ -324,7 +324,7 @@ foo = Just 3   >>= (\x ->
       Just "!" >>= (\y -> 
       Just (show x ++ y)))
 ```
-On récupère deux valeurs de monades à travers x et y, puis l'on place le résultat de show x ++ y dans un contexte. C'est lourd a écrire, demande l'imbrication de fonctions... Avec la notation do, cela évident :
+On récupère deux valeurs de monades à travers x et y, puis l'on place le résultat de show x ++ y dans un contexte. C'est lourd à écrire, demande l'imbrication de fonctions... Avec la notation do, cela évident :
 ``` haskell
 foo :: Maybe String  
 foo = do  
@@ -342,7 +342,7 @@ foo = do
 
 Dans les deux premières lignes, on récupère `x` et `y` depuis `Just 3` et `Just "!"`, puis on fait notre traitement.
 
-Hey! Mais ça ressemble a des listes en compréhension tout ça! Reproduisons le même exercice mais avec des listes :
+Hey! Mais ça ressemble à des listes en compréhension tout ça! Reproduisons le même exercice mais avec des listes :
 ``` haskell
 foo :: Maybe String  
 foo = [1, 2, 3]   >>= (\x -> 
@@ -350,7 +350,7 @@ foo = [1, 2, 3]   >>= (\x ->
           [show x ++ y]))
 ```
 
-Le résultat produit est toute les façons de coller l'un des signes de ponctuation après l'un des nombres. C'est exactement la même chose que :
+Le résultat produit est toutes les façons de coller l'un des signes de ponctuation après l'un des nombres. C'est exactement la même chose que :
 ``` haskell
 foo :: Maybe String  
 foo = do
@@ -362,9 +362,9 @@ foo = do
 foo = [show x ++ y | x <- [1, 2, 3] | y <- [".", "!", "?"]]
 ```
 
-Voilà donc l'origine des liste en compréhension! Et oui, il nous aura fallu arriver jusqu'ici pour pouvoir enfin expliquer ce que sont les liste en compréhension. C'est simplement un sucre syntaxique spécifique au liste d'un bloque do. C'est donc de la manipulation de monade que vous faites, à chaque fois que vous écrivez une liste en compréhension. Si c'est si pratique avec les listes, vous vous doutez bien que pouvoir le faire avec diverses structures (des arbres par exemple), est tout aussi pratique.
+Voilà donc l'origine des liste en compréhension! Et oui, il nous aura fallu arriver jusqu'ici pour pouvoir enfin expliquer ce que sont les listes en compréhension. C'est simplement un sucre syntaxique spécifique aux listes d'un bloc do. C'est donc de la manipulation de monade que vous faites, à chaque fois que vous écrivez une liste en compréhension. Si c'est si pratique avec les listes, vous vous doutez bien que pouvoir le faire avec diverses structures (des arbres par exemple), est tout aussi pratique.
 
-Vous vous demandez alors comment ajouter les conditions, comme dans `[x^2 | x <- [1..20], x `mod` 2 == 0]` ? Et bien vous pouvez utilisez la fonction `guard`, qui produiras une liste vide si la condition n'est pas vérifiée :
+Vous vous demandez alors comment ajouter les conditions, comme dans `[x^2 | x <- [1..20], x `mod` 2 == 0]` ? Et bien vous pouvez utilisez la fonction `guard`, qui produira une liste vide si la condition n'est pas vérifiée :
 ``` haskell
 foo = do
       x <- [1..20]
@@ -374,14 +374,14 @@ foo = do
 
 ### Le retour de Jafar, aussi connu sous le nom de `(->) r`.
 
-Nous avions utilisé le foncteur applicatif `(->) r` pour représenter des calculs qui dépendent d'un contexte. On savais donc appliquer des fonctions `r -> (a -> b)` sur des valeurs `r -> a`. Seulement, il est plus commun de partir d'une valeur, et produire un résultat qui dépend du contexte. On voudrais donc une monade, pour pouvoir combiner des fonctions de type `a -> (r -> b)` (Les parenthèses sont là pour faire ressortir que l'on considère (->) r comme un foncteur / une monade, mais bien sur facultatives).
+Nous avions utilisé le foncteur applicatif `(->) r` pour représenter des calculs qui dépendent d'un contexte. On savait donc appliquer des fonctions `r -> (a -> b)` sur des valeurs `r -> a`. Seulement, il est plus commun de partir d'une valeur, et produire un résultat qui dépend du contexte. On voudrait donc une monade, pour pouvoir combiner des fonctions de type `a -> (r -> b)` (Les parenthèses sont là pour faire ressortir que l'on considère (->) r comme un foncteur / une monade, mais bien sur facultatives).
 
 Comme `(->) r` est l'une des monades les plus abstraites, regardons un exemple concret, où le contexte est la position d'une caméra dans un raytracer.
 
 ``` haskell
 -- On définit une caméra.
--- Une caméra contient la position depuis la quelle
--- les rayons sont lancé, la distance à la quel se trouve
+-- Une caméra contient la position depuis laquelle
+-- les rayons sont lancés, la distance à laquelle se trouve
 -- le plan, et la taille de celui ci.
 type Position = (Double, Double, Double)
 type Direction = (Double, Double, Double)
@@ -392,7 +392,7 @@ type Hauteur = Coordonnee
 type Plan = (Largeur, Hauteur)
 data Camera = Camera Position Distance Plan
 
-getRay :: Cooronnee -> (Camera -> Direction)
+getRay :: Coordonnee -> (Camera -> Direction)
 getRay (i, j) cam = let (Camera (x, y, z) _ _ _) = cam in normalize (i - x, j - y, -z)
   where
     normalize (x, y, z) = let norme = sqrt(x^2 + y^2 + z^2) in (x / norm, y / norm, z / norm)
@@ -408,15 +408,15 @@ computeColor = -- Calcule la couleur en tenant compte de l'angle de la caméra, 
 -- C'est pourquoi le type est "Camera -> Coordonnee -> [Word8]" plutôt
 -- que "Coordonnee -> Camera -> [Word8]". On perd donc la possibilité
 -- d'utiliser getPixel avec la monade "(->) Camera".
-getPixel :: Camera -> Coordonee -> [Word8])
+getPixel :: Camera -> Coordonnee -> [Word8]
 getPixel cam coords = (return coords >>= getRay >>= (rayTraceScene uneScene) >>= computeColor) cam
 ```
 
 ### Point culture
 
-Comprenez bien que les monades ne sont pas indispensable, et que l'on faisait des monade avant la première apparition de la classe Monade. C'est simplement de nouveaux outils à votre disposition pour résoudre des problèmes, et ils permettent parfois de vieux problèmes de façon très élégante et concise (ce qui est un excellent pour l'évolutivité d'un code).
+Comprenez bien que les monades ne sont pas indispensables, et que l'on faisait des monades avant la première apparition de la classe Monade. C'est simplement de nouveaux outils à votre disposition pour résoudre des problèmes, et ils permettent parfois de résoudre de vieux problèmes de façon très élégante et concise (ce qui est un excellent pour l'évolutivité d'un code).
 
-Sachez que les monades aussi doivent respecter certaines règles, tous comme les foncteurs et les foncteurs applicatifs. Cela assure qu'une monade seras bien un foncteur (applicatif), de la façon décrite plus haut. Les voici :
+Sachez que les monades aussi doivent respecter certaines règles, tout comme les foncteurs et les foncteurs applicatifs. Cela assure qu'une monade sera bien un foncteur (applicatif), de la façon décrite plus haut. Les voici :
 ``` haskell
 -- Neutre à gauche
 return a >>= f = f a
@@ -428,16 +428,16 @@ m >>= return = m
 
 Vous trouverez des liens dans les références pour plus de détails.
 
-On n'a pas aborder la monade IO. Cette monade permet de ramener les actions propre a l'impératif, les "effets de bord", dans le langage haskell. L'astuce diabolique est la suivante : Puisque qu'un programme haskell ne peut produire d'effet de bord, un programme haskell décriras comment composer, jusxtaposer, et transformer les résultats produits par des programmes impératif. Utiliser la monade IO, c'est jouer avec la composition et la juxtaposition de programmes. C'est alors que l'opérateur `>>` prend tout son sens! Il permet de juxtaposer deux programmes impératifs et ne retenir le résultat que du second, par exemple :
+On n'a pas abordé la monade IO. Cette monade permet de ramener les actions propres à l'impératif, les "effets de bord", dans le langage haskell. L'astuce diabolique est la suivante : Puisque qu'un programme haskell ne peut produire d'effet de bord, un programme haskell décrira comment composer, juxtaposer, et transformer les résultats produits par des programmes impératifs. Utiliser la monade IO, c'est jouer avec la composition et la juxtaposition de programmes. C'est alors que l'opérateur `>>` prend tout son sens! Il permet de juxtaposer deux programmes impératifs et ne retenir le résultat que du second, par exemple :
 ``` haskell
 afficherMessage = putStrLn "Bonjour," >> putStrLn "monde!"
 ```
 
-En dire plus sur cette monade n'a d'intérêts que pour les personne voulant écrire des programmes en haskell. Si c'est votre cas, je vous invite à lire, au choix, Learn You Haskell for Great Good ou (plus technique et plus ... "professionnel") Real World Haskell, chez O'Reilly.
+En dire plus sur cette monade n'a d'intérêt que pour les personnes voulant écrire des programmes en haskell. Si c'est votre cas, je vous invite à lire, au choix, Learn You Haskell for Great Good ou (plus technique et plus ... "professionnel") Real World Haskell, chez O'Reilly.
 
 ### Références :
 
-  * [Les lois respectés par les monades][monades-laws]
+  * [Les lois respectées par les monades][monades-laws]
   * La monade [Either][either]
   * Le moteur de recherche haskell [Hoogle][hoogle]. Permet de rechercher une fonction à partir de son type.
 

--- a/_posts/led-matrix-10x10/2012-06-06-led-matrix-10x10.md
+++ b/_posts/led-matrix-10x10/2012-06-06-led-matrix-10x10.md
@@ -1,8 +1,8 @@
 ---
 layout: post
 title: Construire sa matrice de led 10x10 pour l'utiliser avec une carte Arduino.
-description: Réalisation des pistes et soudure d'une matrices de diodes pour utiliser
-  comme surface d'affichage avec une carte arduino.
+description: Réalisation des pistes et soudure d'une matrice de diodes pour utiliser
+  comme surface d'affichage avec une carte Arduino.
 author: Jérémy Cochoy
 date: 2012-06-06 +0100
 categories: hardware led diy arduino
@@ -14,31 +14,31 @@ redirect_from:
 
 ## Matrice de LED 10x10 pour une alimentation 5V
 
-Dans ce billet, je vais développer les différentes étapes dans la réalisation d'une matrice de diode 10x10 pour une utilisation avec des tensions de 5V (Il faudra prévoir une/des résistances dans le circuit qui contrôleras les transistors).
+Dans ce billet, je vais développer les différentes étapes dans la réalisation d'une matrice de diodes 10x10 pour une utilisation avec des tensions de 5V (Il faudra prévoir une/des résistances dans le circuit qui contrôlera les transistors).
 
-Quel est l’intérêt de réaliser une matrice soit même?
-Certainement pas le prix, puisqu'on trouve des matrices 8x8 à 3€ sur un célèbre site d'enchère.
-Ni la qualité esthétique, puisque vous vous rendrez vite compte qu’aligner parfaitement les diodes relèverais du miracle.
+Quel est l’intérêt de réaliser une matrice soi-même?
+Certainement pas le prix, puisqu'on trouve des matrices 8x8 à 3€ sur un célèbre site d'enchères.
+Ni la qualité esthétique, puisque vous vous rendrez vite compte qu’aligner parfaitement les diodes relèverait du miracle.
 
-Non, ce que l'on cherche ici, c'est la satisfaction d'avoir réalisé son premier circuit, et d'avoir fait le premier pas vers un nouveau monde. À mes yeux, ce projet est le plus simples des projets utile accessible à un néophyte, et fait suite à l'hello world.
+Non, ce que l'on cherche ici, c'est la satisfaction d'avoir réalisé son premier circuit, et d'avoir fait le premier pas vers un nouveau monde. À mes yeux, ce projet est le plus simple des projets utiles accessible à un néophyte, et fait suite à l'hello world.
 
 ![Le projet terminé](data/led_matrix.png)
 
 
-Je vous fourni le projet Eagle contenant schéma et PCB, pour que vous puissiez imprimer le PCB ou simplement modifier le design ; [led_matrix.7z](data/led_matrix.7z).
+Je vous fournis le projet Eagle contenant schéma et PCB, pour que vous puissiez imprimer le PCB ou simplement modifier le design ; [led_matrix.7z](data/led_matrix.7z).
 
 
 ## Dessin du circuit (PCB), détermination des composants
 
-La première étape consiste à réaliser le circuit via un logiciel spécialisé, par exemple Eagle, en s’aidant des lois de la physique (Loi des mailles, des noeuds, et U=RI :) ) pour s'assurer que l'on a les bonnes tensions / intensités. J'ai réaliser les calculs pour des leds vertes haute luminosité. Notez que le seuil de tension (aussi appelé Forward Voltage) des led vari aelon les couleurs (2~2.6v pour les rouges/oranges/jaunes et 3~4V pour les vertes/bleu). Dans la configuration que j'ai réaliser, prévu pour une alimentation de 5V, on ne peut allumer les LED qu'une à une pour espérer une intensité lumineuse acceptable. Dans l'ensemble, pour l'adapter a d'autres tensions, vous pouvez vous contenter de recalculer/mesurer les résistances.
+La première étape consiste à réaliser le circuit via un logiciel spécialisé, par exemple Eagle, en s’aidant des lois de la physique (Loi des mailles, des noeuds, et U=RI :) ) pour s'assurer que l'on a les bonnes tensions / intensités. J'ai réalisé les calculs pour des leds vertes haute luminosité. Notez que le seuil de tension (aussi appelé Forward Voltage) des led varie selon les couleurs (2~2.6v pour les rouges/oranges/jaunes et 3~4V pour les vertes/bleu). Dans la configuration que j'ai réalisée, prévue pour une alimentation de 5V, on ne peut allumer les LED qu'une à une pour espérer une intensité lumineuse acceptable. Dans l'ensemble, pour l'adapter à d'autres tensions, vous pouvez vous contenter de recalculer/mesurer les résistances.
 
-Notez que les transistors n'ont pas de résistance sur leur base. Vous DEVEZ en placer. Pour ma part elles figureront coté contrôleur, car je prévoir l'usage d'un démultiplexeur qui diminuera le nombre de résistances nécessaires.
+Notez que les transistors n'ont pas de résistance sur leur base. Vous DEVEZ en placer. Pour ma part elles figureront côté contrôleur, car je prévois l'usage d'un démultiplexeur qui diminuera le nombre de résistances nécessaires.
 
 Voilà la bête :
 
 ![Schéma de la matrice](data/led_matrix_sch.png)
 
-Une fois le schéma réalisé, le choix des connecteurs fait, les connexions vérifiés, on peut passer au dessin du PCB. Une petite réflexion vous conduira a la conclusion qu'il est impossible de relier les connexions avec une piste de cuivre simple face sans qu'elles se chevauchent. La solution? De petits fils qui vont venir jouer le rôle de pont. Cela se caractérise par le fait que les pistes ne sont pas complètement reliés, comme Eagle l’indique par la présence de 'fils aériens'. Sachez au passage que j'ai du réaliser le rooting (câblage) à la main, pour obtenir quelque chose d'esthétique.
+Une fois le schéma réalisé, le choix des connecteurs fait, les connexions vérifiées, on peut passer au dessin du PCB. Une petite réflexion vous conduira à la conclusion qu'il est impossible de relier les connexions avec une piste de cuivre simple face sans qu'elles se chevauchent. La solution? De petits fils qui vont venir jouer le rôle de pont. Cela se caractérise par le fait que les pistes ne sont pas complètement reliées, comme Eagle l’indique par la présence de 'fils aériens'. Sachez au passage que j'ai dû réaliser le rooting (câblage) à la main, pour obtenir quelque chose d'esthétique.
 
 ![Le PCB](data/led_matrix_pcb.png)
 
@@ -46,11 +46,11 @@ Après tout ce travail, il ne reste qu'à prier pour que ne figurent pas d'erreu
 
 ## Le montage
 
-Après quelques semaines, je reçoit le circuit que j'avais commandé. Et oui, vous avez crus que je ferait le circuit moi même? Commandé auprès d'un particulier qui ne traite que les commandes de particuliers ; <http://etronics.free.fr> si vous me demandez de le dénoncer. Je sort les câbles, la soudure, et me prépare à poser la "deuxième couche" du circuit. Ah mais, il ne manquerait pas la moitié des trous?!
+Après quelques semaines, je reçois le circuit que j'avais commandé. Et oui, vous avez cru que je ferais le circuit moi-même? Commandé auprès d'un particulier qui ne traite que les commandes de particuliers ; <http://etronics.free.fr> si vous me demandez de le dénoncer. Je sors les câbles, la soudure, et me prépare à poser la "deuxième couche" du circuit. Ah mais, il ne manquerait pas la moitié des trous?!
 
 --------------------------------------------------------------------------------
 
-Bon, on essaye de retourner la situation à son avantage. Et si on se contentais de petites agrafes reliés entre elles via un long fil métallique? Mais oui! Ça fonctionne, et c'est même très pratique!
+Bon, on essaye de retourner la situation à son avantage. Et si on se contentait de petites agrafes reliées entre elles via un long fil métallique? Mais oui! Ça fonctionne, et c'est même très pratique!
 
 ![Placement des bootstraps en agrafes.](data/led_matrix_01.png)
 ![Deuxième piste](data/led_matrix_01.png)
@@ -70,20 +70,20 @@ C'est terminé!
 ## Petit rappel sur l'utilisation
 
  -  On n'allume qu'une led à la fois, quitte à le faire assez vite pour donner
-    l'illusion que plusieurs sont allumé en même temps. Un affichage à 60kHz est suffisant.
+    l'illusion que plusieurs sont allumées en même temps. Un affichage à 60kHz est suffisant.
  -  Il faut penser à mettre des résistances sur la base des transistors
     (Les headers C1-C10).
  -  Pour activer la diode en (4,8) (Avec la disposition où est prise la
     première photographie) on branche 5V sur L8 et l'on active C4 avec par
-	exemple une résistance 10K relié à 5V.
+	exemple une résistance 10K reliée à 5V.
 
 
 __À vous de faire une plus grosse matrice! ;)__
 
-__NB :__ Le montage que j'ai fait n'est pas la seul solution pour réduire le nombre
+__NB :__ Le montage que j'ai fait n'est pas la seule solution pour réduire le nombre
 de connections. Il existe des multiplexages à 'haute impédance', se basant sur
 le fait que l'on ne connecte que 2 broches sur l'ensemble des combinaisons
-possible ([Sonelec-musique](http://www.sonelec-musique.com/electronique_bases_affichage_multiplexage.html)).
-Je ne garantit pas que ce soit une bonne idée pour utiliser conjointement avec
-des LED haute luminosité et un microcontroleur. Si quelqu'un a testé, je suis
+possibles ([Sonelec-musique](http://www.sonelec-musique.com/electronique_bases_affichage_multiplexage.html)).
+Je ne garantis pas que ce soit une bonne idée pour utiliser conjointement avec
+des LED haute luminosité et un microcontrôleur. Si quelqu'un a testé, je suis
 curieux de savoir ce que ça donne.

--- a/_posts/list-zipper-swift/2019-05-24-list-zipper-swift.md
+++ b/_posts/list-zipper-swift/2019-05-24-list-zipper-swift.md
@@ -9,7 +9,7 @@ lang: en
 ...
 
 Recently, I was implementing a model for a music application where the user
-edit a collection of tracks, while editing only one track at a time.
+edits a collection of tracks, while editing only one track at a time.
 After a little thought, the best representation of this “focus” in the data
 model was obviously a zipper.
 Since this is not a common pattern, I thought it would be a wonderful example
@@ -18,10 +18,10 @@ of how such a simple pattern can encode the intention into the data structure.
 ## Abstract idea
 The Zipper is a well known pattern in Haskell,
 and although this language is rarely used in production,
-some of its usage translate very well to other languages.
+some of its usages translate very well to other languages.
 The List Zipper is basically a list where the element we are focusing at
 was taken out.
-It allow shifting the attention to the previous or next element,
+It allows shifting the attention to the previous or next element,
 and obviously to retrieve the whole list if required.
 
 ## Usage
@@ -42,7 +42,7 @@ print(zippy.toList().joined(separator: " ")) // Eat pancakes
 ```
 
 ## Implementation
-Let’s start by the data itself.
+Let’s start with the data itself.
 We need to store the element of the list we are looking at (the cursor).
 Since we are focusing on an element of the list,
 we also need to remember what was before this element, and what comes next.
@@ -59,11 +59,11 @@ struct ListZipper<T> {
 }
 ```
 
-Now that we have the informations,
+Now that we have the information,
 we need a way to convert from a list to a ListZipper,
 and from a ListZipper to a list.
 We add an initializer with as a default an empty list,
-and a function that glue together the beginning of the list, the cursor,
+and a function that glues together the beginning of the list, the cursor,
 and the remaining part of the list.
 
 ```swift
@@ -82,13 +82,13 @@ and the remaining part of the list.
   }
 ```
 
-Notice how we handle the case where the curser is pointing to nothing.
-(A case which could occurs from an empty list / empty zipper.)
+Notice how we handle the case where the cursor is pointing to nothing.
+(A case which could occur from an empty list / empty zipper.)
 
 Our zipper can store the information,
 but is always pointing to the first element of the list.
 This is pretty boring and not really useful.
-We introduce two functions that allow to move on the right or the left of
+We introduce two functions that allow moving to the right or the left of
 our band.
 
 ```swift
@@ -109,7 +109,7 @@ mutating func right() {
 }
 ```
 
-I personally choose to add guards for my particular usage,
+I personally chose to add guards for my particular usage,
 because I always want to be pointing to a music track if my song is not empty.
 But you could safely remove them.
 In this setting you’d know you are on the bounds simply by checking if the
@@ -117,7 +117,7 @@ cursor is pointing to nothing.
 
 One crucial step remaining to make this Zipper fully usable is a way to insert
 and remove elements at the current location.
-I choose to always insert on the right of the element pointed.
+I chose to always insert on the right of the element pointed.
 Symmetrically, when I remove the pointed element,
 I automatically look to the left.
 
@@ -142,7 +142,7 @@ mutating func remove() {
 ```
 
 Notice that in the case you removed the guard in the left/right functions,
-you can also simplify remove by only poping the value from `leftList`.
+you can also simplify remove by only popping the value from `leftList`.
 
 Now you have a simple but powerful zipper in your hands.
 For more fanciness, one could also enjoy the natural functoriality of the list

--- a/_posts/music-box/2013-08-16-music-box.md
+++ b/_posts/music-box/2013-08-16-music-box.md
@@ -1,8 +1,8 @@
 ---
 layout: post
 title: Boite à musique Arduino
-description: Une micro-bibliothèque pour jouer une mélodie polyphonique sur arduino en C.
-  Contient le code, la documentation, et la melodie de tétris comme exemple.
+description: Une micro-bibliothèque pour jouer une mélodie polyphonique sur Arduino en C.
+  Contient le code, la documentation, et la mélodie de Tétris comme exemple.
 author: Jérémy Cochoy
 date: 2013-08-16 +0100
 categories: arduino software music asm c embeded
@@ -11,17 +11,17 @@ redirect_from:
   - /blog/arduino
 ...
 
-Dans la lignée du dépoussiérage de vieux codes, j'ai ressorti un jeu de quelques fonctions pour arduino que je n'avais pas eu le temps de publier. Il s'agit d'une certaine façon d'une bibliothèque similaire à la lib "Tone" fournie avec l'Arduino. Toutefois, contrairement à cette dernière, c'est bien un instrument polyphonique dont vous disposez. À dire vrai, il y a 4 canaux d'onde carré, et un canal de bruit. On peut de plus régler l'amplitude sonore de chacun des canaux entre 0 (minimum) et 255 (maximum). Il y a tout de même une contrainte ; la somme des amplitudes ne doit pas excéder 255. Ainsi, jouer de la musique est relativement simple. Il suffit de choisir la fréquence et l'amplitude de chaque canal, puis d'attendre un certain laps de temps (fonction delay fournis avec les libs de l'arduino) avant de recommencer. Le bruit est généré grâce à une table de valeurs aléatoires près-calculés, pour des raisons de performances. Vous pouvez réduire ou augmenter la taille de cette table à votre guise, un "script C++"(trop peu de lignes pour parler de programme) permettant de générer le header.
+Dans la lignée du dépoussiérage de vieux codes, j'ai ressorti un jeu de quelques fonctions pour Arduino que je n'avais pas eu le temps de publier. Il s'agit d'une certaine façon d'une bibliothèque similaire à la lib "Tone" fournie avec l'Arduino. Toutefois, contrairement à cette dernière, c'est bien un instrument polyphonique dont vous disposez. À dire vrai, il y a 4 canaux d'onde carrée, et un canal de bruit. On peut de plus régler l'amplitude sonore de chacun des canaux entre 0 (minimum) et 255 (maximum). Il y a tout de même une contrainte ; la somme des amplitudes ne doit pas excéder 255. Ainsi, jouer de la musique est relativement simple. Il suffit de choisir la fréquence et l'amplitude de chaque canal, puis d'attendre un certain laps de temps (fonction delay fournie avec les libs de l'Arduino) avant de recommencer. Le bruit est généré grâce à une table de valeurs aléatoires pré-calculées, pour des raisons de performances. Vous pouvez réduire ou augmenter la taille de cette table à votre guise, un "script C++"(trop peu de lignes pour parler de programme) permettant de générer le header.
 
 Tout ceci est plutôt abstrait, alors regardons cela de plus près.
 
 ## Montage de test :
 
-Le montage de test est très similaire à celui du tutoriel tone. Seul change le port sur lequel vous devez connecter votre speacker.
+Le montage de test est très similaire à celui du tutoriel tone. Seul change le port sur lequel vous devez connecter votre speaker.
 
 [![Montage arduino](data/music_box_arduino.png)](data/music_box_arduino.png)
 
-Donc, une résistance d'une centaine d'ohms (prenez ce que vous avez sous la main, plus la résistance sera élevée, moins le volume le sera) reliée à un speacker, ou bien à une prise JACK pour brancher vos enceintes favorites.
+Donc, une résistance d'une centaine d'ohms (prenez ce que vous avez sous la main, plus la résistance sera élevée, moins le volume le sera) reliée à un speaker, ou bien à une prise JACK pour brancher vos enceintes favorites.
 
 Si vous souhaitez changer le port de sortie, il vous faudra toucher au code (et au code asm aussi :/) car le code utilise un mécanisme de l'ATMEGA328P qui n'est disponible que sur les ports 11, 10, 9, 6, 5 et 3 de l'arduino (ceux marqués d'une petite vague). De plus, si vous souhaitez utiliser le port 3 conjointement à ce code, vous risquez d'avoir quelques soucis. (Ces ports sont regroupés en paires, et chaque port d'une paire ne peut émettre un signal qu'à la même fréquence. Vous ne pourrez pas non plus utiliser l'interruption du timer 2, utilisé par ces deux ports. Ici, le code utilise la fréquence maximum possible, donc cela ne devrait à priori pas poser de soucis pour les utilisations les plus simples du port 3, comme contrôler l'intensité lumineuse d'une led).
 
@@ -36,7 +36,7 @@ extern int square3_period;
 extern int square4_period;
 ```
 
-En fait, c'est la période de l'onde qui est stockée, exprimée en 62500ième de seconde. Une macro, frequency_to_period(f), s'occupe de convertir une fréquence f (en Hz) en une période. Un exemple d'utilisation serait :
+En fait, c'est la période de l'onde qui est stockée, exprimée en 62500e de seconde. Une macro, frequency_to_period(f), s'occupe de convertir une fréquence f (en Hz) en une période. Un exemple d'utilisation serait :
 ``` c
 square1_period = frequency_to_period(440); //Le LA de référence est à 440Hz
 ```
@@ -65,7 +65,7 @@ extern unsigned char noise_amplitude;
 ```
 C'est un canal qui émet un son similaire à celui d'un vieux téléviseur sans antennes, un "Tshhhhh" très caractéristique. À nouveau, en faisant varier l'amplitude (on parle de modulation d'amplitude), vous pouvez créer le timbre de divers instruments de percussion. La fonction `play_seawave();` est un exemple.
 
-Le bruit est près calculé grâce au programme C++ *generate_white_noise.cpp.src* (qui n'est autre qu'un fichier .cpp). Vous pouvez le bidouiller pour diminuer ou agrandir la table.
+Le bruit est pré-calculé grâce au programme C++ *generate_white_noise.cpp.src* (qui n'est autre qu'un fichier .cpp). Vous pouvez le bidouiller pour diminuer ou agrandir la table.
 
 Code et exemple de test
 =======================
@@ -1307,14 +1307,14 @@ Le tar.gz : [synth_8bits.tar](data/synth_8bits.tar.gz).
 
 ## Extrait sonore du code de démonstration
 
-Pour vous montrer que je ne plaisante pas quand à la polyphonie, voici deux extraits utilisant 2 canaux. (Bon, le dernier accord en utilise 3, mais on ne s'en rend pas compte.)
+Pour vous montrer que je ne plaisante pas quant à la polyphonie, voici deux extraits utilisant 2 canaux. (Bon, le dernier accord en utilise 3, mais on ne s'en rend pas compte.)
 
 [Première partie](data/arduino_tetris.mp3)
 [Seconde partie](data/arduino_tetris_effects.mp3)
 
 ## Pour aller plus loin
 
-N'hésitez pas à supprimer quelques canaux, comme le 4ième canal, si vous ne l'utilisez pas et trouvez que votre application est trop lente (i.e. supprimer le bloc de code suivant).
+N'hésitez pas à supprimer quelques canaux, comme le 4e canal, si vous ne l'utilisez pas et trouvez que votre application est trop lente (i.e. supprimer le bloc de code suivant).
 ``` c
   //---------------
   //-  SQUARE  4  -
@@ -1323,7 +1323,7 @@ N'hésitez pas à supprimer quelques canaux, comme le 4ième canal, si vous ne l
   //---------------
 ```
 
-Vous pouvez aussi supprimer le canal de bruit et le tableau white_noise.h pour gagner un peu de mémoire. Bref, faite ce que vous voulez de ce code!
+Vous pouvez aussi supprimer le canal de bruit et le tableau white_noise.h pour gagner un peu de mémoire. Bref, faites ce que vous voulez de ce code!
 
 ### Quelques références :
 

--- a/_posts/ocaml-discovery/2009-11-21-ocaml-discovery.md
+++ b/_posts/ocaml-discovery/2009-11-21-ocaml-discovery.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Découverte d'OCAML
-description: Une courte introduction au language de programmation OCAML.
+description: Une courte introduction au langage de programmation OCAML.
 author: Jérémy Cochoy
 date: 2009-11-21 +0100
 categories: programming functional ocaml language
@@ -10,18 +10,18 @@ lang: fr
 
 ## Découverte d'OCAML
 
-Dans ce petit article, je compte vous parler d'un langage de programmation assez particulier :  (O)CAML. Tout d'abord, si j'ajoute une parenthèse devant la première lettre du sigle, c'est que je ne compte pas aborder toute la partie OBJET de langage, ni la partie impérative. N'espérez donc pas voir une seul structure conditionnel (_if_) ou itérative (_while_/_for_) dans ce texte.
+Dans ce petit article, je compte vous parler d'un langage de programmation assez particulier :  (O)CAML. Tout d'abord, si j'ajoute une parenthèse devant la première lettre du sigle, c'est que je ne compte pas aborder toute la partie OBJET de langage, ni la partie impérative. N'espérez donc pas voir une seule structure conditionnelle (_if_) ou itérative (_while_/_for_) dans ce texte.
 
 ## Propositions : définitions et expressions :
 
-Tout comme en mathématique chaque phrase est une proposition, en ocaml chaque "ligne" est une proposition. Elle commence avec le premier caractère et se termine avec le symbole ';;'
+Tout comme en mathématiques chaque phrase est une proposition, en ocaml chaque "ligne" est une proposition. Elle commence avec le premier caractère et se termine avec le symbole ';;'
 
-Il y a deux type de propositions :
+Il y a deux types de propositions :
  *  Les expressions : De la forme $$3*7$$ ou encore $$\sqrt[7]{\frac{2^9}{3^{43}}}$$
  *  Les définitions : De la forme $$q := \sqrt{2}$$ qui déclare q comme un alias de $$\sqrt{2}$$
 
 En ocaml, la syntaxe est la suivante :
- *  Pour un expression :
+ *  Pour une expression :
     ``` ocaml
     3 * 7;;
     ```
@@ -36,23 +36,23 @@ En ocaml, la syntaxe est la suivante :
 
 ## L'aspect fonctionnel
 
-Mais comment un tel langage peut-il exister, et surtout, être 'utilisable' sans pour autant faire usage des structures des langages impératif comme le C ou le Python? (Je m'adresse bien-sur ici a ceux qui n'ont pas encore été initier aux joies des langages fonctionnel)
+Mais comment un tel langage peut-il exister, et surtout, être 'utilisable' sans pour autant faire usage des structures des langages impératifs comme le C ou le Python? (Je m'adresse bien sûr ici à ceux qui n'ont pas encore été initiés aux joies des langages fonctionnels)
 
 Tout d'abord, définissons ce qu'est un langage fonctionnel. Par analogie à un langage objet où les éléments sont des objets(Dans certains cas, TOUS les éléments), dans un langage fonctionnel, les éléments sont des fonctions, au sens mathématique du terme.
 
 Si l'on considère la fonction suivante : $$\begin{array}{ccccc} f & : & \mathbb{Z} & \to & \mathbb{Z}^2 \\ & & x & \mapsto & (x, x) \end{array}$$
 
-C'est la fonction qui associe à un entier $$x$$ son couple situer sur sa diagonal(injection diagonal) $$(x,x) \in \Delta\mathbb{Z} \subset \mathbb{Z}^2$$
+C'est la fonction qui associe à un entier $$x$$ son couple situé sur sa diagonale (injection diagonale) $$(x,x) \in \Delta\mathbb{Z} \subset \mathbb{Z}^2$$
 
 Il est alors très aisé de définir f en ocaml :
 ```{.ocaml}
 let f x = (x, x);
 ```
-Cette fonction est de type `int -> int * int`, c'est a dire qu'elle prend un entier $$int \approx \mathbb{Z}$$ et retourne un couple $$(x, y) \in \mathbb{Z} \times \mathbb{Z}$$.
+Cette fonction est de type `int -> int * int`, c'est-à-dire qu'elle prend un entier $$int \approx \mathbb{Z}$$ et retourne un couple $$(x, y) \in \mathbb{Z} \times \mathbb{Z}$$.
 
-On peut bien-sur définir des fonctions de fonction. Observons la fonction "composition"(rond) : $$\begin{array}{ccccc} o & : & (\mathbb{B} \Rightarrow \mathbb{C} ) \times (\mathbb{A} \Rightarrow \mathbb{B} ) & \longrightarrow & (\mathbb{A} \to \mathbb{C} ) \\ & & (f, g) & \longmapsto & (x \mapsto f(g(x)) \end{array}$$.
+On peut bien sûr définir des fonctions de fonction. Observons la fonction "composition"(rond) : $$\begin{array}{ccccc} o & : & (\mathbb{B} \Rightarrow \mathbb{C} ) \times (\mathbb{A} \Rightarrow \mathbb{B} ) & \longrightarrow & (\mathbb{A} \to \mathbb{C} ) \\ & & (f, g) & \longmapsto & (x \mapsto f(g(x)) \end{array}$$.
 
-En OCAML, on aurais :
+En OCAML, on aurait :
 ``` ocaml
 let o f g = f g;;
 (* val o : ('a -> 'b) -> 'a -> 'b = <fun> *)
@@ -60,9 +60,9 @@ let o f g = f g;;
 
 ## Les filtres
 
-Je vous ai parler un peut plus tôt de l'absence de structures conditionnel et itératif, je vais ici vous exposer les solutions a votre disposition.
+Je vous ai parlé un peu plus tôt de l'absence de structures conditionnelles et itératives, je vais ici vous exposer les solutions à votre disposition.
 
-Commençons avec les blocs conditionnel. En OCAML, nous disposons d'une fonction-alitée très intéressante : les filtres.
+Commençons avec les blocs conditionnels. En OCAML, nous disposons d'une fonctionnalité très intéressante : les filtres.
 Si l'on considère la fonction continue suivante : $$\begin{array}{ccccc} f & : & \mathbb{Z} & \to & \mathbb{Z} \\ & & x & \mapsto &
 \left\{
 \begin{array}{ccc}
@@ -71,14 +71,14 @@ x < 0 & \Rightarrow & -2x \\ x \ge 0 &  \Rightarrow & x^2
 \right.
 \end{array}$$
 
-On constate que l'on a bien deux condition, une première qui regroupe les cas des x négatif, et une deuxième qui s'intéresse aux x restant. En OCAML, on défini de la même façon :
+On constate que l'on a bien deux condition, une première qui regroupe les cas des x négatifs, et une deuxième qui s'intéresse aux x restant. En OCAML, on définit de la même façon :
 ``` ocaml
 let f = function
   | x when x < 0 -> -2 * x
   | x when x >= 0 -> x*x
   ;;
 ```
-Ou bien, en omettant la deuxième condition et en considérons que la dernière condition matcheras pour "tous les cas restant"
+Ou bien, en omettant la deuxième condition et en considérant que la dernière condition matchera pour "tous les cas restants"
 ``` ocaml
 let f = function
   | x when x < 0 -> -2 * x
@@ -86,12 +86,12 @@ let f = function
   ;;
 ```
 
-Dans le cas où l'on a pas besoin de nommer x, on peut utiliser _. Ainsi, un dernier cas `_ -> smtg` correspondrais un peut à 'default' d'un switch.
-On pourras aussi utiliser l'instruction match {variable} with {filtre}.
+Dans le cas où l'on n'a pas besoin de nommer x, on peut utiliser _. Ainsi, un dernier cas `_ -> smtg` correspondrait un peu à 'default' d'un switch.
+On pourra aussi utiliser l'instruction match {variable} with {filtre}.
 
-## La récursivité terminal
+## La récursivité terminale
 
-Maintenant, considérons les itérations. Nous allons utiliser la récursivités terminal(tail-rec pour les intimes) afin de construire une boucle. La récursivité terminale est une forme de récursivité ou l'unique action qui succède à l'appelle a la fonction récursive est un retour de valeur.
+Maintenant, considérons les itérations. Nous allons utiliser la récursivité terminale (tail-rec pour les intimes) afin de construire une boucle. La récursivité terminale est une forme de récursivité où l'unique action qui succède à l'appel à la fonction récursive est un retour de valeur.
 
 C'est plutôt élémentaire :
 ``` ocaml
@@ -100,12 +100,12 @@ let rec aff_n = function
   | n -> print_endline (string_of_int n);
            aff_n (n - 1);;
 ```
-() représente le type 'unit', c'est a dire que notre fonction ne retourne rien, tout comme print_endl. Nous obtenons une boucle de 10 à 1, et nous affichons les valeurs a l'écran.
-Vous vous demandez alors, pourquoi de la tail rec et non une simple récursivités? La réponse est que l'interpréteur/compilateur optimise par une itération, ce qui est bien plus pratique pour nos machines qui on une mémoire limiter et ne peuvent supporter qu'un nombre restreins d'appelles récursif.
+() représente le type 'unit', c'est-à-dire que notre fonction ne retourne rien, tout comme print_endl. Nous obtenons une boucle de 10 à 1, et nous affichons les valeurs à l'écran.
+Vous vous demandez alors, pourquoi de la tail rec et non une simple récursivité? La réponse est que l'interpréteur/compilateur optimise par une itération, ce qui est bien plus pratique pour nos machines qui ont une mémoire limitée et ne peuvent supporter qu'un nombre restreint d'appels récursifs.
 
 ## Pour conclure
 
-OCAML est un langage fonctionnel, qui bon nombre d'aspects et concepts qui sont parfois inconnus des programmeurs aillant pratiquer uniquement des langages impératif, et constitue de par son existence une forme de culture dont il peut-être bon d'avoir connaissance.
+OCAML est un langage fonctionnel, qui comporte bon nombre d'aspects et concepts qui sont parfois inconnus des programmeurs ayant pratiqué uniquement des langages impératifs, et constitue de par son existence une forme de culture dont il peut être bon d'avoir connaissance.
 
 ### Références :
 

--- a/_posts/polynomial-degree-3/2011-02-25-polynomial-degree-3.md
+++ b/_posts/polynomial-degree-3/2011-02-25-polynomial-degree-3.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: De la résolution d'équations polynomial de degré 3
-description: Implémentation de la résolution d'équation polynomiales
+title: De la résolution d'équations polynomiales de degré 3
+description: Implémentation de la résolution d'équations polynomiales
   de degré 3. Peut être appliqué par exemple en raytracing.
 author: Jérémy Cochoy
 date: 2011-02-25 +0100
@@ -14,38 +14,38 @@ redirect_from:
 
 ## La recherche de racine pour des polynômes du 3ème degré
 
-$$\Delta = b^2 - 4ac$$, voici une formule que la plupart d'entre vous on appris très jeunes
+$$\Delta = b^2 - 4ac$$, voici une formule que la plupart d'entre vous ont appris très jeunes
 et dont la simple lecture évoque immédiatement la résolution de polynômes du second degré.
 
-Mais vous êtes vous déjà pausé la question de la résolution d'équations mettant en jeu des polynômes du troisième degré, ou pire, d'un degré encore plus élevé?
+Mais vous êtes-vous déjà posé la question de la résolution d'équations mettant en jeu des polynômes du troisième degré, ou pire, d'un degré encore plus élevé?
 
-Sachez que pour les dégrées strictement supérieur à 4, les équations ne sont alors plus "soluble par radicaux". Ce que l'on pourrais résumer à "finis les belles formules magiques au dessus du degré 4".
+Sachez que pour les degrés strictement supérieurs à 4, les équations ne sont alors plus "solubles par radicaux". Ce que l'on pourrait résumer à "finis les belles formules magiques au dessus du degré 4".
 
-Dans cette article, nous nous intéresserons à la méthode de Tartaglia-Cardan, du nom de ces deux célèbres mathématiciens, respectivement a l'origine de la méthode et de sa publication. (Je vous invite a en apprendre plus sur nos deux protagoniste, ainsi que Ferrari - le secrétaire de cardan - à qui l'on dois la résolution des équations de degré 4 par radicaux.)
+Dans cet article, nous nous intéresserons à la méthode de Tartaglia-Cardan, du nom de ces deux célèbres mathématiciens, respectivement à l'origine de la méthode et de sa publication. (Je vous invite à en apprendre plus sur nos deux protagonistes, ainsi que Ferrari - le secrétaire de Cardan - à qui l'on doit la résolution des équations de degré 4 par radicaux.)
 
-Nous chercherons à adapter la méthode "papier" pour une application informatique, affin d'obtenir une valeur réel avec une précision convenable. Nous ne chercherons donc pas la réponse "exacte" comme l'on peut la trouver avec un crayon et beaucoup de papier.
+Nous chercherons à adapter la méthode "papier" pour une application informatique, afin d'obtenir une valeur réelle avec une précision convenable. Nous ne chercherons donc pas la réponse "exacte" comme l'on peut la trouver avec un crayon et beaucoup de papier.
 
-Sachez que résoudre des équations de degré 3 peut avoir de nombreuse applications, et que probablement certains de mes lecteurs souhaiteront la mettre en œuvre dans le cadre d'un raytracer d'ici la fin de l'année scolaire. Plus que de donner une implémentation, je souhaite ici détailler la logique qui en est à l'origine.
+Sachez que résoudre des équations de degré 3 peut avoir de nombreuses applications, et que probablement certains de mes lecteurs souhaiteront la mettre en œuvre dans le cadre d'un raytracer d'ici la fin de l'année scolaire. Plus que de donner une implémentation, je souhaite ici détailler la logique qui en est à l'origine.
 
 ## Étape 1 ) Changement de variable
 
-La méthode de cardan ne s'applique qu'à des polynômes de la forme $$Z^3 + pZ + q = 0$$ et nous cherchons une solution pour tout polynôme de la forme $$aX^3 + bX^2 + cX + d = 0$$
+La méthode de Cardan ne s'applique qu'à des polynômes de la forme $$Z^3 + pZ + q = 0$$ et nous cherchons une solution pour tout polynôme de la forme $$aX^3 + bX^2 + cX + d = 0$$
 
-On considéreras donc deux cas : Notre polynôme a son coefficient du second degré nulle, et dans ce cas on n'effectue pas de changement de variable, on le rend juste unitaire(diviser par a). Dans le cas contraire, on pauseras $$X = Z - \frac{b}{3a}$$, ce qui nous amène a calculer à calculer $$p = - \frac{b^2}{3a^2} + \frac{c}{a}$$ et $$q = \frac{b}{27a}\left(\frac{2b^2}{a^2}-\frac{9c}{a}\right)+\frac{d}{a}$$ (en développant le polynôme $$a(Z - \frac{b}{3a})^3 + b(Z - \frac{b}{3a})^2 + c(Z - \frac{b}{3a}) + d = 0$$) , et par la suite ajouter $$\frac{b}{3a}$$ a nos solutions.
+On considérera donc deux cas : notre polynôme a son coefficient du second degré nul, et dans ce cas on n'effectue pas de changement de variable, on le rend juste unitaire (diviser par a). Dans le cas contraire, on posera $$X = Z - \frac{b}{3a}$$, ce qui nous amène à calculer $$p = - \frac{b^2}{3a^2} + \frac{c}{a}$$ et $$q = \frac{b}{27a}\left(\frac{2b^2}{a^2}-\frac{9c}{a}\right)+\frac{d}{a}$$ (en développant le polynôme $$a(Z - \frac{b}{3a})^3 + b(Z - \frac{b}{3a})^2 + c(Z - \frac{b}{3a}) + d = 0$$) , et par la suite ajouter $$\frac{b}{3a}$$ à nos solutions.
 
 Voici le code c correspondant :
 ```c
 int cardan(float a, float b, float c, float d, float resultat[3])
 // -&gt; resultat est notre tableau de solutions
-//Retourne le nombre de racines trouvé
+//Retourne le nombre de racines trouvées
 {
   //Nos coefs
   float p;
   float q;
-  //Ce que nous ajouterons a nos solution, si le changement de variable a eu lieu
+  //Ce que nous ajouterons à nos solutions, si le changement de variable a eu lieu
   float correction = 0;
 
-  //Si il n'y a pas besoin de changement de variable
+  //S'il n'y a pas besoin de changement de variable
   if (b == 0)
   {
     p = c / a;
@@ -63,28 +63,28 @@ int cardan(float a, float b, float c, float d, float resultat[3])
 
 ## Étape 2 ) Système solution
 
-Nous entrons enfin dans le vif du sujet. Comment allons nous maintenant trouver les racines de notre polynôme? Pour commencer, nous savons qu'il existe au moins une racine réel (Un polynôme de degré impaire admet toujours au moins une racine réel) que l'on peut écrire sous la forme v + u, v et u deux réels. (Car, évidemment, rien ne nous empêche d'écrire 3 comme 2+1, ou 3+0!)
+Nous entrons enfin dans le vif du sujet. Comment allons-nous maintenant trouver les racines de notre polynôme? Pour commencer, nous savons qu'il existe au moins une racine réelle (un polynôme de degré impair admet toujours au moins une racine réelle) que l'on peut écrire sous la forme v + u, v et u deux réels. (car, évidemment, rien ne nous empêche d'écrire 3 comme 2+1, ou 3+0!)
 
-A ce stade, si nous développons notre polynôme avec u+v, nous obtenons $$v^3+u^3+(3uv+p)(u+v)+q=0$$ (modulo une factorisation par (u+v) ).
-Puisque nous pouvons "répartir" notre solution "un peut dans u, le reste dans v" comme nous le souhaitons, rien ne nous empêche de fixer $$3uv+p = 0$$ (ou encore $$uv = \frac{-p}{3u}$$
+À ce stade, si nous développons notre polynôme avec u+v, nous obtenons $$v^3+u^3+(3uv+p)(u+v)+q=0$$ (modulo une factorisation par (u+v) ).
+Puisque nous pouvons "répartir" notre solution "un peu dans u, le reste dans v" comme nous le souhaitons, rien ne nous empêche de fixer $$3uv+p = 0$$ (ou encore $$uv = \frac{-p}{3u}$$
 
 On remarque alors que notre polynôme se simplifie, laissant apparaître $$u^3 + v^3= -q$$
 
-En d'autre termes, notre solution est donc solution du système $$\begin{cases}u^3+v^3&=-q\\ u^3v^3&=-\frac{p^3}{27}\end{cases}$$ (et doivent respecter en plus la condition $$3uv+p = 0$$).
+En d'autres termes, notre solution est donc solution du système $$\begin{cases}u^3+v^3&=-q\\ u^3v^3&=-\frac{p^3}{27}\end{cases}$$ (et doivent respecter en plus la condition $$3uv+p = 0$$).
 
-Vous remarquerez alors que connaissant le produit et la somme de deux nombres a et b, nous pouvons nous servir du polynôme du second dégrée $$x^2 -(a + b)X + ab = 0$$ qui a pour racines a et b. Appliquons ceci à $$u^3$$ et $$v^3$$
+Vous remarquerez alors que connaissant le produit et la somme de deux nombres a et b, nous pouvons nous servir du polynôme du second degré $$x^2 -(a + b)X + ab = 0$$ qui a pour racines a et b. Appliquons ceci à $$u^3$$ et $$v^3$$
 
-On résout donc $$X^2+qX-\frac{p^3}{27}=0$$. Attention, les solutions sont soit complexe, soit réels, soit réels double (u = v). Dans le cas de solutions pour u et v réels, leur racine cubique est un réel unique et nous aurons donc l'unique racine du polynôme. Dans le cas de solutions complexe(non nulle) pour u et v, nous aurons alors 3 racines cubiques pour u et 3 pour v. Nous verrons dans le paragraphe suivant comment calculer ces racines et trouver les bonnes combinaisons.
+On résout donc $$X^2+qX-\frac{p^3}{27}=0$$. Attention, les solutions sont soit complexes, soit réelles, soit réelles doubles (u = v). Dans le cas de solutions pour u et v réelles, leur racine cubique est un réel unique et nous aurons donc l'unique racine du polynôme. Dans le cas de solutions complexes (non nulles) pour u et v, nous aurons alors 3 racines cubiques pour u et 3 pour v. Nous verrons dans le paragraphe suivant comment calculer ces racines et trouver les bonnes combinaisons.
 
-Voici l'implémentation pour les racines réels :
+Voici l'implémentation pour les racines réelles :
 ```c
   // ... next block :
   float delta = q*q + 4 * p*p*p / 27; //On applique delta = b^2+4ac où b=q, a=1, c = -p^3/27
-  // Racine double réel =&gt; 3 solutions réels, dont une double
+  // Racine double réelle =&gt; 3 solutions réelles, dont une double
   if (delta == 0)
   {
     //En grattant beaucoup de papier, on parvient à calculer directement
-    // les raine sans utiliser pow. Nous en profitons donc :
+    // les racines sans utiliser pow. Nous en profitons donc :
     float z1 = 3.f * q / p;
     float z2 = -3.f / 2.f * q / p;
     resultat[0] = z1 + correction;
@@ -93,7 +93,7 @@ Voici l'implémentation pour les racines réels :
     //Finalement, ce polynôme a 3 racines :
     return 3;
   }
-  // Une unique solution réel
+  // Une unique solution réelle
   else if (delta &gt; 0)
   {
     //La racine carré de delta :
@@ -114,52 +114,52 @@ Voici l'implémentation pour les racines réels :
     //to be continue
 ```
 
-## Étape 3 ) Racines complexe : un peu de géométrie
+## Étape 3 ) Racines complexes : un peu de géométrie
 
 Multiplier un complexe $$a$$ par un complexe $$b$$, c'est obtenir
 un complexe $$c$$ dont la norme est le produit $$|a| |b|$$,
 et l'argument la somme $$arg(a) + arg(b)$$. D'un point de vue géométrique,
 le produit $$a b$$ est une rotation de $$a$$ d'angle $$arg(b)$$ dans le sens trigonométrique,
 et une homothétie par le scalaire $$|b|$$.
-Où cela nous conduit-il? A la définition d'une racine cubique d'un complexe.
+Où cela nous conduit-il? À la définition d'une racine cubique d'un complexe.
 Soit $$a = |a|e^{arg(a)}$$ le complexe d'argument $$arg(a)$$ et de norme $$|a|$$,
 on a pour racine cubique : $$z_1 = \sqrt[3]{|a|}e^{arg(a)}$$, $$z_2 = \sqrt[3]{|a|}e^{arg(a)/3 + 2\pi/3}$$
 $$z_3 = \sqrt[3]{|a|}e^{arg(a)/3 + 4\pi/3}$$
 
 De façon générale, les racines nièmes d'un complexe d'argument $$arg(a)$$ et de norme $$|a|$$ est
 la rotation de $$\frac{arg(a)}{n}$$ et homothétie de scalaire $$\sqrt[3]{|a|}$$ des racines
-nième complexe de 1 (pouvant elles même être considéré comme un polygone...)
+nièmes complexes de 1 (pouvant elles-mêmes être considérées comme un polygone...)
 
-Bref, de belles façons d'interpréter les choses, mais en quoi cela nous aide-il?
+Bref, de belles façons d'interpréter les choses, mais en quoi cela nous aide-t-il?
 
-Et bien, si nous pouvions connaître l'argument d'un complexe et son module, nous pourrions calculer numériquement l'argument et le module de ses racines, et ainsi trouver les valeurs possible pour u et v. Considérons donc nos solutions complexe comme les points d'un plan. Le module et l'argument forment alors leur coordonnées polaire.
-Nous avons le système suivant qui lit les coordonnées cartésiennes d'un point à ses coordonnées polaire : \[\begin{cases}x&=r cos(\alpha)\\ y&=r sin(\alpha)\end{cases}\] De plus, nous pouvons calculer $$r$$, en appliquant le théorème de Pythagore.
-Si l'on fait alors le quotient de x par y, on obtient $$tan(\alpha)$$. En fait, en étudiant le signe de x et de y, on peut connaitre le signe de alpha et donc utiliser la fonction arc tangente (`atan` en C). C'est  la réciproque de tangente,
-modulo le bonne ensemble de définition.
-Pour se simplifier la tache dans l'implémentation C du calcul de l'arc tangente, on peut utiliser la fonction `atan2(x, y)` qui effectue le quotient et tien compte des signes.
+Et bien, si nous pouvions connaître l'argument d'un complexe et son module, nous pourrions calculer numériquement l'argument et le module de ses racines, et ainsi trouver les valeurs possibles pour u et v. Considérons donc nos solutions complexes comme les points d'un plan. Le module et l'argument forment alors leurs coordonnées polaires.
+Nous avons le système suivant qui lie les coordonnées cartésiennes d'un point à ses coordonnées polaires : \[\begin{cases}x&=r cos(\alpha)\\ y&=r sin(\alpha)\end{cases}\] De plus, nous pouvons calculer $$r$$, en appliquant le théorème de Pythagore.
+Si l'on fait alors le quotient de x par y, on obtient $$tan(\alpha)$$. En fait, en étudiant le signe de x et de y, on peut connaître le signe de alpha et donc utiliser la fonction arc tangente (`atan` en C). C'est  la réciproque de tangente,
+modulo le bon ensemble de définition.
+Pour se simplifier la tâche dans l'implémentation C du calcul de l'arc tangente, on peut utiliser la fonction `atan2(x, y)` qui effectue le quotient et tient compte des signes.
 
-Encore un dernier détaille, et nous avons terminé. Les solutions que nous trouverons pour u et v peuvent se classer par paire de conjugué (les racines de u et v correspondant a la même racine cubique de 1). On remarque alors que les solutions seront toute bien réel. (La partie imaginaire de chacun des conjugué s'annulant.) Bien, passons à l'implémentation :
+Encore un dernier détail, et nous avons terminé. Les solutions que nous trouverons pour u et v peuvent se classer par paires de conjugués (les racines de u et v correspondant à la même racine cubique de 1). On remarque alors que les solutions seront toutes bien réelles. (La partie imaginaire de chacun des conjugués s'annulant.) Bien, passons à l'implémentation :
 ```c
   // ... last block :
     //On commence par prendre la valeur absolue de delta
     //Par la suite, on suppose delta &gt; 0.
     delta = -delta;
-    //Petit rappelle, nos solutions sont de la forme : -q/2 +- i sqrt(delta)/2
+    //Petit rappel, nos solutions sont de la forme : -q/2 +- i sqrt(delta)/2
     //Donc, de module au carré r^2 = (-q/2)^2 + (sqrt(delta)/2)^2 = q^2/4 + (delta)/4
-    //FInalement r = sqrt(q^2 + delta) / sqrt(4)
+    //Finalement r = sqrt(q^2 + delta) / sqrt(4)
     //Calculons le module :
     float r = sqrt(q*q + delta) / 2;
-    //Maintenant, l'argument de nos complexe. Si deux complexe sont des conjugué, alors
-    // ils on simplement leur argument de signe opposé. Comme on peux indifféremment inverser u et v, nous n'avons
+    //Maintenant, l'argument de nos complexes. Si deux complexes sont des conjugués, alors
+    // ils ont simplement leur argument de signe opposé. Comme on peut indifféremment inverser u et v, nous n'avons
     // pas besoin de tan2.
     // En simplifiant y / x, on trouve +-sqrt (delta) / q
     float alpha = atan(sqrt(delta) / q);
-    // Nous calculons l'argument et le module d'une des racine complexe
-    // (Celle au plus petit argument, c'est a dire Theta + 0PI/3)
+    // Nous calculons l'argument et le module d'une des racines complexes
+    // (Celle au plus petit argument, c'est-à-dire Theta + 0PI/3)
     // Par la suite, alpha = theta et r = r^(1/3)
     r = pow(r, 1.f/3.f);
     alpha = alpha / 3.f;
-    //Nous pouvons donc calculer nos trois racines réels, en passant de coordonnée polaire à des coordonnées cartésiennes.
+    //Nous pouvons donc calculer nos trois racines réelles, en passant de coordonnées polaires à des coordonnées cartésiennes.
     //De plus, nous simplifions et ne calculons pas la partie imaginaire, qui comme expliqué précédemment est nulle
     resultat[0] = 2 * r * cos(alpha) + correction; //nous avons effectivement r*cos(alpha) + r*cos(alpha)
     resultat[1] = 2 * r * cos(alpha + 2*PI/3) + correction;
@@ -170,17 +170,17 @@ Encore un dernier détaille, et nous avons terminé. Les solutions que nous trou
 //Ouf! C'est terminé!
 ```
 
-Pour conclure, un petit coup de wikipedia vous montreras que l'on peut simplifier le calcule du module, et n'utiliser qu'une simple racine carrée. Pensez aussi que si vous pouvez éviter de calculer deux fois la même chose, vous gagnerez en performance. Pensez a factoriser les expression de manière a ce que les produits/quotient soient résolut à la compilation et cherchez a minimiser les produits/quotient.
+Pour conclure, un petit coup de Wikipédia vous montrera que l'on peut simplifier le calcul du module, et n'utiliser qu'une simple racine carrée. Pensez aussi que si vous pouvez éviter de calculer deux fois la même chose, vous gagnerez en performance. Pensez à factoriser les expressions de manière à ce que les produits/quotients soient résolus à la compilation et cherchez à minimiser les produits/quotients.
 
-Notez que celons le contexte, on préférera considérer une racine double qu'une seule fois, affin d'éviter la redondance des calcules.
+Notez que selon le contexte, on préférera considérer une racine double qu'une seule fois, afin d'éviter la redondance des calculs.
 
 ## Sur papier?
 
 Sachez que la méthode papier consiste à effectuer le même raisonnement que nous avons
-mené jusqu'au calcule du discriminant du polynôme qui nous permet de trouver a et b.
-Dans le cas $$\Delta <= 0$$, on calculeras la racine cubique et on factoriseras le polynôme
+mené jusqu'au calcul du discriminant du polynôme qui nous permet de trouver a et b.
+Dans le cas $$\Delta <= 0$$, on calculera la racine cubique et on factorisera le polynôme
 pour faire apparaître les racines.
-Dans le cas de complexes, on pourras être amener a chercher les racines d'un nouveau
+Dans le cas de complexes, on pourra être amené à chercher les racines d'un nouveau
 polynôme du 3ème degré pour simplifier l'expression des racines.
 Bien que la méthode de Tartaglia-Cardan soit une méthode qui fonctionne parfaitement,
 il n'est pas toujours facile de calculer les racines d'un polynôme de degré 3.

--- a/_posts/pwm-fast-frequency/2012-04-30-pwm-fast-frequency.md
+++ b/_posts/pwm-fast-frequency/2012-04-30-pwm-fast-frequency.md
@@ -2,7 +2,7 @@
 layout: post
 title: ATMega328 (Arduino uno) TimerCounter et PWM à 62,5kHz
 description: On discute ici du générateur d'onde carré de l'ATMega328, et de
-  comment l'utiliser pour synthétiser un signal sonore quelconque en temps réelle.
+  comment l'utiliser pour synthétiser un signal sonore quelconque en temps réel.
   On repousse ainsi les limites de la bibliothèque musicale arduino.
 author: Jérémy Cochoy
 date: 2012-04-30 +0100
@@ -15,47 +15,47 @@ redirect_from:
   - /blog/windows-keyboard-mapping/fr.html
 ...
 
-## Timer/Counter et PWM pour des fréquences élevés.
+## Timer/Counter et PWM pour des fréquences élevées.
 
-Cette article traite de l'utilisation de certaines fonctionnalités de l'ATMega328P qui peuvent s’avérer utiles pour le traitement des signaux audio (par exemple, réaliser une pédale d'effet), jouer des samples de musique (échantillonnés à 44100Hz ou moins), ou encore réaliser de la synthèse sonore.
+Cet article traite de l'utilisation de certaines fonctionnalités de l'ATMega328P qui peuvent s’avérer utiles pour le traitement des signaux audio (par exemple, réaliser une pédale d'effet), jouer des samples de musique (échantillonnés à 44100Hz ou moins), ou encore réaliser de la synthèse sonore.
 
-Il est question d'aborder ici le stricte minimum pour utiliser le PWM (Pulse Width Modulation) à une fréquence suffisamment élevé affin de pouvoir générer un signale analogique et de contrôler son amplitude. En bonus, nous pourrons exécuter une interruption toute les 16uS.
+Il est question d'aborder ici le strict minimum pour utiliser le PWM (Pulse Width Modulation) à une fréquence suffisamment élevée afin de pouvoir générer un signal analogique et de contrôler son amplitude. En bonus, nous pourrons exécuter une interruption toutes les 16uS.
 
-Je recommande fortement au gens aillant un peut d'expérience de lire directement la documentation relative aux Timers/Counters, PWM, et aux registres DDRx/PORTx.
+Je recommande fortement aux gens ayant un peu d'expérience de lire directement la documentation relative aux Timers/Counters, PWM, et aux registres DDRx/PORTx.
 
 ### Timer et PWM
 
-L'ATMega328P comprend 3 Timers, c'est à dire trois compteurs qui sont incrémenté par le microcontroleur tout les N ticks d'horloges (K peut valoir 1, 8, 32, 64, 256, 1024 celons vos envies). Ces timers se noment "Timer0", "Timer1" et "Timer2".  Le Timer0 est utilisé par la bibliothèque arduino pour évaluer l'écoulement du temps (delay, microsecond) et pour les sorties PWM associés à ce timer. Le Timer1 dispose d'un compteur 16bits, c'est à dire de 0 à 0xFFFF, alors que les timers 2 et 1 sont en 8bits (de 0 à 0xFF). L'idée est que nous voulons compter vite, très vite, donc nous avons intéret à utiliser un compteur 8bits. Notre choix se port donc tout naturellement sur le timer2.
+L'ATMega328P comprend 3 Timers, c'est-à-dire trois compteurs qui sont incrémentés par le microcontrôleur tous les N ticks d'horloge (K peut valoir 1, 8, 32, 64, 256, 1024 selon vos envies). Ces timers se nomment "Timer0", "Timer1" et "Timer2".  Le Timer0 est utilisé par la bibliothèque arduino pour évaluer l'écoulement du temps (delay, microsecond) et pour les sorties PWM associées à ce timer. Le Timer1 dispose d'un compteur 16bits, c'est-à-dire de 0 à 0xFFFF, alors que les timers 2 et 1 sont en 8bits (de 0 à 0xFF). L'idée est que nous voulons compter vite, très vite, donc nous avons intérêt à utiliser un compteur 8bits. Notre choix se porte donc tout naturellement sur le timer2.
 
-Le PWM correspond à la mise sous tension d'une patte de l'ATMega durant un certain laps de temps, puis de sa mise à 0 durant un autre instant, et le tout répété très rapidement. Cela permet de simuler un signale analogique de tension comprise entre 5v et 0v (Moins si vous n'utilisez pas l'alimentation 5V). Le principe est très bien décrit par le schéma suivant provenant du site d'arduino(http://arduino.cc/en/Tutorial/PWM) :
+Le PWM correspond à la mise sous tension d'une patte de l'ATMega durant un certain laps de temps, puis de sa mise à 0 durant un autre instant, et le tout répété très rapidement. Cela permet de simuler un signal analogique de tension comprise entre 5v et 0v (Moins si vous n'utilisez pas l'alimentation 5V). Le principe est très bien décrit par le schéma suivant provenant du site d'arduino(http://arduino.cc/en/Tutorial/PWM) :
 
 ![PWM on Arduino](data/pwm.gif)
 
-Il faut savoir que chaque Timer controle deux sorties PWM. Les pattes correspondant à ces sorties sont indiqué sur la page 2 de la documentation atmel (OCnA et OCnB, où n est le numéro du timer). Dans notre cas nous utiliseront la sortie OC2A, qui correspond au pin 11 d'une carte arduino.
+Il faut savoir que chaque Timer contrôle deux sorties PWM. Les pattes correspondant à ces sorties sont indiquées sur la page 2 de la documentation atmel (OCnA et OCnB, où n est le numéro du timer). Dans notre cas nous utiliserons la sortie OC2A, qui correspond au pin 11 d'une carte arduino.
 
-Le fonctionnement du PWM est extrêmement simple ; Vous réglez le PWM avec une valeur comprise entre 0 et 255, disons C. Alors, tant que le compteur est plus petit que C, il y auras une tension de 5V sur la sortie OC2A. Quand le compteur dépasse C, la tension passe à 0V. Pour accélérer une sortie PWM, il faut donc accélérer le timer qui est associé.
+Le fonctionnement du PWM est extrêmement simple ; Vous réglez le PWM avec une valeur comprise entre 0 et 255, disons C. Alors, tant que le compteur est plus petit que C, il y aura une tension de 5V sur la sortie OC2A. Quand le compteur dépasse C, la tension passe à 0V. Pour accélérer une sortie PWM, il faut donc accélérer le timer qui est associé.
 
 ### Le mode FastPWM (ATMega328P datasheet p152-153)
 
-Il existe plusieurs configurations possible pour la sortie PWM, la fréquence des timers, etc. Je vous conseille très fortement de lire la documentation atmel à ce sujet. Dans notre cas, nous cherchons la plus rapide, et il y en a une qui correspond tout à fait à nos besoins ; La configuration Fast PWM.
+Il existe plusieurs configurations possibles pour la sortie PWM, la fréquence des timers, etc. Je vous conseille très fortement de lire la documentation atmel à ce sujet. Dans notre cas, nous cherchons la plus rapide, et il y en a une qui correspond tout à fait à nos besoins ; La configuration Fast PWM.
 
-Le compteur que nous avons évoqué, associé au Timer2, se nome "TCNT2"(Timer Counter 2), et peut être lut et écrit à tout moment. La valeur à partir de la quel le signal bascule de 5V à 0V est stocké dans OCR2A(Output Compare Register 2 A). Un second registre de comparaison est disponible, OCR2B, et correspond au pin OC2B.
+Le compteur que nous avons évoqué, associé au Timer2, se nomme "TCNT2"(Timer Counter 2), et peut être lu et écrit à tout moment. La valeur à partir de laquelle le signal bascule de 5V à 0V est stockée dans OCR2A(Output Compare Register 2 A). Un second registre de comparaison est disponible, OCR2B, et correspond au pin OC2B.
 
-Dans ce mode, le comTCNT2 part de 0, puis atteint progressivement OCR2A. Alors, la tension de sortie de OC2A s'inverse. À cette instant, une interruption peut être déclenchée. C'est à dire, si vous n'êtes pas familier avec ce mécanisme, qu'une fonction que vous aurez préalablement écrite, compilé, et associé à ce mécanisme, seras exécuté. De même pour OCR2B/OC2B.
+Dans ce mode, le compteur TCNT2 part de 0, puis atteint progressivement OCR2A. Alors, la tension de sortie de OC2A s'inverse. À cet instant, une interruption peut être déclenchée. C'est-à-dire, si vous n'êtes pas familier avec ce mécanisme, qu'une fonction que vous aurez préalablement écrite, compilée, et associée à ce mécanisme, sera exécutée. De même pour OCR2B/OC2B.
 
-Le compteur continus sa montée, et atteint alors 0xFF. Il y a alors overflow : le compteur repasse à 0x00 à la prochaine incrémentation, et enclenche l'interruption TIMER2_OVF (Timer 2 Overflow), si elle est activée.
+Le compteur continue sa montée, et atteint alors 0xFF. Il y a alors overflow : le compteur repasse à 0x00 à la prochaine incrémentation, et enclenche l'interruption TIMER2_OVF (Timer 2 Overflow), si elle est activée.
 
 Sachez enfin que vous pouvez configurer si la tension de sortie avant que le compteur atteigne OCR2A doit être haute ou basse. Nous choisirons qu'elle est haute, puis basse. De cette façon, si OCR2A = 0, la tension sera 0 sur une période (16us, pour mémoire), et si OCR2A = 0xFF, elle sera de 5V (toujours sur une période).
 
-Le schéma suivant, issu de la documentation, décrit une succession d’interventions sur le registre OCR2A, l'évolution du compteur, le déclenchement des interruptions, et les tensions de sorties(haut pour 5V et bas pour 0V) celons la configuration des deux bits COM2A1 et COM2A0 (Pour les valeur 2( = 1 0 en binaire) et 3 = (1 1 en binaire))
+Le schéma suivant, issu de la documentation, décrit une succession d’interventions sur le registre OCR2A, l'évolution du compteur, le déclenchement des interruptions, et les tensions de sorties (haut pour 5V et bas pour 0V) selon la configuration des deux bits COM2A1 et COM2A0 (Pour les valeurs 2( = 1 0 en binaire) et 3 = (1 1 en binaire))
 
 ![FastPWM Atmel ATMega328p](data/FastPWM_Atmel_atmega38p.png)
 
-La fréquence à la quel l’interruption TOV2(TIMER2_OVF) est appelé se calcul aisément à partir de celle de l'horloge de l'ATMega. Si vous utilisez un quartz externe à 16MHz (c'est le cas des cartes arduino) la fréquence est alors $\frac{f_{clock}}{N . 256}$ où $N$ est le facteur d'échelle (prescale factor), dont nous parlerons un peu plus loin.
+La fréquence à laquelle l’interruption TOV2(TIMER2_OVF) est appelée se calcule aisément à partir de celle de l'horloge de l'ATMega. Si vous utilisez un quartz externe à 16MHz (c'est le cas des cartes arduino) la fréquence est alors $\frac{f_{clock}}{N . 256}$ où $N$ est le facteur d'échelle (prescale factor), dont nous parlerons un peu plus loin.
 
 L'activation du mode FastPWM (p160 de la documentation) se fait en fixant les bits du "Timer Counter Control Register"  A et B (TCCR2A et TCCR2B).
 
-Le premier contient le type de sortie COM2A1:0 et COM2B1:0, ainsi que les bits WGM21 WMGM20 contrôlant le mode de l'horloge.  Le second (p163)  contient le dernier bit de configuration du mode, WGM22 et les trois bits permettant de sélectionner le facteur d'échelle (dans notre cas, nous choisirons 1, pour que la fréquence soit la plus élevé) ; CS22, CS21, CS20.
+Le premier contient le type de sortie COM2A1:0 et COM2B1:0, ainsi que les bits WGM21 WMGM20 contrôlant le mode de l'horloge.  Le second (p163)  contient le dernier bit de configuration du mode, WGM22 et les trois bits permettant de sélectionner le facteur d'échelle (dans notre cas, nous choisirons 1, pour que la fréquence soit la plus élevée) ; CS22, CS21, CS20.
 
 Ainsi, nous pouvons déjà configurer le mode Fast PWM :
 ``` c
@@ -67,9 +67,9 @@ Nb : Sachez que pour chacun des modes, vous trouverez un tel schéma dans la doc
 ### Facteur d'échelle
 
 Les bits CS22, CS21 et CS20 permettent de configurer le facteur d’échelle.
-Le concept est simple (p155 et p156 de la documentation pour des schéma
-extrêmement claires) ; le compteur TCNT2 seras incrémenté de 1 tout
-les N ticks d'horloge, où la valeur de n dépend du facteur d'échelle choisit,
+Le concept est simple (p155 et p156 de la documentation pour des schémas
+extrêmement clairs) ; le compteur TCNT2 sera incrémenté de 1 tous
+les N ticks d'horloge, où la valeur de N dépend du facteur d'échelle choisi,
 d'après le tableau suivant (p164 de la documentation) :
 
 ![Clock Select Bit Description](data/csb_desc.png)
@@ -77,7 +77,7 @@ d'après le tableau suivant (p164 de la documentation) :
 
 ### Activer la sortie PWM
 
-Nous avons donc configurer le compteur, et la sortie PWM peut maintenant être utilisée. Mais encore faut-il l'activer. Pour cela, il faut sélectionner la "direction" du pin associé au comparateur A (OC2A) comme "OUTPUT". Cela se fait via le Data Direction Register B (car la sortie OC2A est la troisième patte du port B, c'est à dire la sortie 11 de la carte arduino).
+Nous avons donc configuré le compteur, et la sortie PWM peut maintenant être utilisée. Mais encore faut-il l'activer. Pour cela, il faut sélectionner la "direction" du pin associé au comparateur A (OC2A) comme "OUTPUT". Cela se fait via le Data Direction Register B (car la sortie OC2A est la troisième patte du port B, c'est-à-dire la sortie 11 de la carte arduino).
 ``` c
 DDRB |= 1 << DDB3;
 ```
@@ -85,7 +85,7 @@ Pour désactiver la sortie PWM lorsque le pin est toujours en mode output, il su
 
 ### Utiliser les interruptions
 
-Le dernier outil, pour pouvoir par exemple effectuer une acquisition audio à  $31,25kHz$, est interruption OVF, déclenchée dès que le compteur passe de 0xFF à 0x00.  Pour ce faire, il faut informer le compilateur que votre fonction doit être associé à une interruption, et activer l'interruption grâce au masque d’interruption TIMSK2.
+Le dernier outil, pour pouvoir par exemple effectuer une acquisition audio à  $31,25kHz$, est interruption OVF, déclenchée dès que le compteur passe de 0xFF à 0x00.  Pour ce faire, il faut informer le compilateur que votre fonction doit être associée à une interruption, et activer l'interruption grâce au masque d’interruption TIMSK2.
 ``` c
 // Configuration
 TIMSK2 = 1 << TOIE2;
@@ -100,7 +100,7 @@ ISR(TIMER2_OVF_vect)
 
 ### La bibliothèque C AVR
 
-Si nous pouvons utiliser toute ces macros, c'est bien quelles sont définit quelques part. Il s'agit d'une bibliothèque C permettant de développer sur les microcontroleurs atmel en C. Cette bibliothèque contient une documentation dont je recommande chaudement la lecture, notamment pour ceux qui souhaiterais diminuer le temps perdu en entête C dans l’interruption OVF (environs 20 à ticks d'horloge à 16MHz, ce qui représente tout de même 20 à 30 256ième du temps d’exécution de votre microcontroleur!)
+Si nous pouvons utiliser toutes ces macros, c’est bien qu’elles sont définies quelque part. Il s’agit d’une bibliothèque C permettant de développer sur les microcontrôleurs Atmel en C. Cette bibliothèque contient une documentation dont je recommande chaudement la lecture, notamment pour ceux qui souhaiteraient diminuer le temps perdu en entête C dans l’interruption OVF (environ 20 à 30 ticks d’horloge à 16MHz, ce qui représente tout de même 20 à 30 256ièmes du temps d’exécution de votre microcontrôleur !)
 
 Sachez aussi qu'une façon plus agréable d'écrire (1 << ABCD) est _BV(ABCD).
 

--- a/_posts/raspbery-pi-hdmi/2012-08-12-raspbery-pi-hdmi.md
+++ b/_posts/raspbery-pi-hdmi/2012-08-12-raspbery-pi-hdmi.md
@@ -8,9 +8,9 @@ categories: raspbery embeded hdmi adminsys
 lang: en
 ...
 
-Today, I was testing my [RPi][raspbery-wikipedia], just to check that "_everything is alright_". I bought a cheap 1A/5V micro usb power supply from china (from a well known auction website) and writed the official raspbian image. I plugged my new VGA/HDMI flat screen, and booted the RPi. Then.... nothing.
+Today, I was testing my [RPi][raspbery-wikipedia], just to check that "_everything is alright_". I bought a cheap 1A/5V micro USB power supply from China (from a well-known auction website) and wrote the official raspbian image. I plugged my new VGA/HDMI flat screen, and booted the RPi. Then.... nothing.
 
-Actualy, to make it works, I had to modify the `config.txt` file, as said by _Aptoitos_ on [the website rs-online][rs-online] :
+Actually, to make it work, I had to modify the `config.txt` file, as said by _Aptoitos_ on [the website rs-online][rs-online] :
 ```
 hdmi_drive=2
 config_hdmi_boost=4
@@ -20,11 +20,11 @@ hdmi_force_hotplug=1
 disable_overscan=0
 ```
 
-After adding and uncommenting those lines in the config.txt file, it worked fine (although I still have to push the auto button of my screen to tell him something great is coming from HDMI input).
+After adding and uncommenting those lines in the config.txt file, it worked fine (although I still have to push the auto button of my screen to tell it something great is coming from HDMI input).
 
 I can't tell exactly what was the problem (signal too low to be recognized, bad display mode, or something else) but then it works fine, and now I'll have to wait for a USB keyboard :)
 
-For more informations about which setting change what : <http://www.rs-online.com/designspark/electronics/knowledge-item/what-you-need-to-get-your-raspberry-pi-up-and-running>
+For more information about which setting changes what : <http://www.rs-online.com/designspark/electronics/knowledge-item/what-you-need-to-get-your-raspberry-pi-up-and-running>
 
 [raspbery-wikipedia]: https://en.wikipedia.org/wiki/Raspberry_Pi
 [rs-online]: https://www.rs-online.com/designspark/what-you-need-to-get-your-raspberry-pi-up-and-running

--- a/_posts/sednl-simple-event-driven-network-library/2013-08-21-sednl-simple-event-driven-network-library.md
+++ b/_posts/sednl-simple-event-driven-network-library/2013-08-21-sednl-simple-event-driven-network-library.md
@@ -31,7 +31,7 @@ apprendre (moins d'un quart d'heure pour un développeur expérimenté).
 Elle convient parfaitement tant à des projets d’envergure moyenne que des
 projets de taille plus conséquente.
 
-Un court exemple d'utilisation du mécanisme d'évènement coté serveur :
+Un court exemple d'utilisation du mécanisme d'évènement côté serveur :
 ``` cpp
 #include <SEDNL/sednl.hpp>
 
@@ -68,12 +68,12 @@ vos callback pour les évènements provenant d'un même utilisateur
 ne peut être supposé. En contrepartie, vous pouvez contrôler quels
 threads vous allouez à quels évènements.
 
-SedNL fournis aussi des outils légers pour sérialiser et envoyer
+SedNL fournit aussi des outils légers pour sérialiser et envoyer
 de façon fiable les instances de vos classes.
 
 Philosophie particulière de cette bibliothèque : la règle est que même
 dans des conditions difficiles (plus de mémoire disponible, limite de
-connections ouvertes, exceptions levées par vos callback, dysfonctionnement
+connexions ouvertes, exceptions levées par vos callback, dysfonctionnement
 du système dans la gestion des threads, ...) la bibliothèque doit faire tout
 ce qui est possible pour conserver un comportement normal.
 Toutes les exceptions "std::bad_alloc" sont interceptées et traitées
@@ -88,9 +88,9 @@ Il est possible que suite à certaines contraintes techniques SedNL ne soit
 pas la bibliothèque la plus adaptée à votre projet. Une lecture rapide de
 la documentation devrait vous permettre de savoir si SedNL est adapté à
 votre projet, ou si vous devez préférer une autre bibliothèque.
-Par exemple, SedNL n'est pas du tout adapter [à de la RCP](http://en.wikipedia.org/wiki/Remote_procedure_call).
+Par exemple, SedNL n'est pas du tout adapté [à de la RCP](http://en.wikipedia.org/wiki/Remote_procedure_call).
 Même si le mécanisme d'évènement est ce que vous recherchez,
-d'autres alternative C basé aussi sur un mécanisme d'évènement
+d'autres alternatives C basées aussi sur un mécanisme d'évènement
 comme libev / libevent offrent un contrôle plus fin,
 au coût d'une API plus complexe et moins intuitive.
 Gardez aussi à l’esprit que le design encouragé par SedNL devrait

--- a/_posts/tutorial-sednl/2013-08-25-tutorial-sednl.md
+++ b/_posts/tutorial-sednl/2013-08-25-tutorial-sednl.md
@@ -8,8 +8,8 @@ categories: sednl network programming c++ software
 lang: fr
 ...
 
-Ce court tutoriel vas vous apprendre à utiliser la bibliothèque réseau SedNL.
-Grâce à cette bibliothèque facile et rapide à prendre en main, nous réaliseront
+Ce court tutoriel va vous apprendre à utiliser la bibliothèque réseau SedNL.
+Grâce à cette bibliothèque facile et rapide à prendre en main, nous réaliserons
 un client et serveur de chat, ainsi qu'une application de dessin collaborative.
 
 ## Installation de SedNL
@@ -59,7 +59,7 @@ linux ou `cmake-gui.exe` sous Windows.
 Vous pouvez maintenant lancer la compilation avec `make` sous linux,
 et `mingw32-make` sous Windows avec mingw.
 
-Une fois la compilation terminé, vous obtenez une bibliothèque statique
+Une fois la compilation terminée, vous obtenez une bibliothèque statique
 `sednl-1.0.a` et une dynamique `sednl-1.0.so`. (.lib et .dll sous windows).
 
 C'est terminé, nous allons pouvoir compiler notre premier programme.
@@ -67,8 +67,8 @@ C'est terminé, nous allons pouvoir compiler notre premier programme.
 ## Service de log d'extraits de code
 
 Pour nos premiers pas avec cette bibliothèque, nous allons réaliser une
-application cliente capable d'envoyer un extrait de code lue depuis l'entrée
-standard vers un serveur qui loggera tout les extraits reçus, sur sa sortie
+application cliente capable d'envoyer un extrait de code lu depuis l'entrée
+standard vers un serveur qui loggera tous les extraits reçus, sur sa sortie
 standard.
 
 ### Le client
@@ -125,7 +125,7 @@ int main(int argc, char* argv[])
 }
 ```
 
-Si le fichier se nome « client.cpp », vous pouvez le compiler avec la ligne
+Si le fichier se nomme « client.cpp », vous pouvez le compiler avec la ligne
 `clang++ -std=c++11 -I/usr/local/include/sednl-1.0/ -lsednl-1.0 -lpthread client.cpp`.
 
 La première fonction `get_input` lit l'entrée standard et stocke tout l'extrait de code dans une chaîne qu'elle renvoie.
@@ -135,23 +135,23 @@ de l'extrait de code (`argv[0]`).
 
 Enfin, c'est à la ligne 26 que commence vraiment notre programme.
 On commence par ouvrir une connexion vers `localhost`. C'est l'ordinateur
-qui exécute ce programme. On peux aussi indiquer « 127.0.0.1 ».
-Le port sur le quel on cherche à atteindre le serveur est le port « 4280 ».
-Un port n'a pas de réalitée matériel, c'est juste une façon de distinguer
-les différentes connexions ouverte vers un ordinateur.
+qui exécute ce programme. On peut aussi indiquer « 127.0.0.1 ».
+Le port sur lequel on cherche à atteindre le serveur est le port « 4280 ».
+Un port n'a pas de réalité matérielle, c'est juste une façon de distinguer
+les différentes connexions ouvertes vers un ordinateur.
 Le choix du numéro de port est arbitraire, même si l'on cherchera à
 éviter d'utiliser les plus communs (comme 80 pour http,
-20 et 21 pour ftp, etc.) ainsi que les valeurs inférieurs à 1024, car
-certains système requière des privilèges administrateur pour les utiliser.
+20 et 21 pour ftp, etc.) ainsi que les valeurs inférieures à 1024, car
+certains systèmes requièrent des privilèges administrateur pour les utiliser.
 
-La ligne 35 fait deux choses. D'abord, `make_event` fabriquer un objet
+La ligne 35 fait deux choses. D'abord, `make_event` fabrique un objet
 de type `Event` qui contient :
 
 1)  Le nom de l'évènement envoyé au serveur. Ici, `"log_that"`.
-2)  Le nom sous le quel l'extrait de code sera enregistré. Ici, `argv[1]`.
+2)  Le nom sous lequel l'extrait de code sera enregistré. Ici, `argv[1]`.
 3)  L'extrait de code à logger. Ici, `input`.
 
-Une fois l'évènement crée, il est envoyé avec par la fonction membre `send`.
+Une fois l'évènement créé, il est envoyé par la fonction membre `send`.
 
 Enfin, la connexion est fermée à la ligne 37.
 
@@ -160,9 +160,9 @@ levée. Elle est alors attrapée à la ligne 39.
 
 ### Le serveur
 
-Le serveur n'est pas beaucoup plus compliqué. Il doit attendre de nouvelle
-connections, et écrire sur la sortie standard le texte reçu. Attention,
-il faudra bien penser à gérer le cas où deux clients envoie un message
+Le serveur n'est pas beaucoup plus compliqué. Il doit attendre de nouvelles
+connexions, et écrire sur la sortie standard le texte reçu. Attention,
+il faudra bien penser à gérer le cas où deux clients envoient un message
 au même moment. Pour ça, on utilisera une mutex.
 
 

--- a/_posts/what-is-wrong-with-the-object-paradigm/2017-02-17-what-is-wrong-with-the-object-paradigm.md
+++ b/_posts/what-is-wrong-with-the-object-paradigm/2017-02-17-what-is-wrong-with-the-object-paradigm.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: What is wrong with the object paradigm ?
-description: A reflexion on error handling and application modeling
+description: A reflection on error handling and application modeling
   through various variations of data modeling. We look at old C fashion,
   object languages, and more functional approaches.
 author: Jérémy Cochoy
@@ -11,7 +11,7 @@ lang: en
 ---
 
 Disclaimer: Aside from the catchy title,
-the main point of this article is to asks questions about the weakness of OOP
+the main point of this article is to ask questions about the weakness of OOP
 and how some languages provided some element of improvement, by taking a slightly different point of view.
 
 > The object paradigm is fundamentally wrong[^wrong]
@@ -19,19 +19,19 @@ and how some languages provided some element of improvement, by taking a slightl
 If you are curious about programming languages and diverse paradigms,
 you probably heard or read this sentence more than once.
 Through those lines,
-I'll try to draw a picture of the main reason that can lead peoples to this conclusion.
-What are the good side and wrong side of OOP,
+I'll try to draw a picture of the main reason that can lead people to this conclusion.
+What are the good sides and wrong sides of OOP,
 and how we can improve this paradigm by tuning it a little bit.
-This nice "tunning" is actually already part of some languages,
+This nice "tuning" is actually already part of some languages,
 and I'll refer to it as the 'category paradigm'.
 
-## Where does the object paradigm comes from?
+## Where does the object paradigm come from?
 
 First, let's recall how, historically, we came to the object paradigm.
 We are in the late 70s.
 The C language is now famous as it completely changed the way to write code
-compared to assembly, is human readable and have a monstrous expressivity
-in only few language words and
+compared to assembly, is human readable and has a monstrous expressivity
+in only a few language words and
 the procedural paradigm[^procedural-paradigm] (the one you use while writing C)
 is well understood.
 But, as applications grow and get an increasing size,
@@ -41,8 +41,8 @@ the code's complexity is growing exponentially, and code gets harder and harder 
 The object paradigm was developed, expecting to solve the complexity curse.
 Here came OBJC and C++, both in 1983.
 
-Sadly, we know today that OOP wasn't the Holly Graal.
-But what did made peoples believe that it would be, and why is OOP still used today?
+Sadly, we know today that OOP wasn't the Holy Grail.
+But what did make people believe that it would be, and why is OOP still used today?
 
 ## The hopes of OOP
 
@@ -50,23 +50,23 @@ What came out from a lot of procedural development is that you often have types
 that describe some complex structure (for example, linked lists in C are built of chained cells,
 each cell composed of a value and a link to the next cell)
 and functions operating on this type (using the same example,
-function for initialising empty list, destroying list,
-inserting into this list and removing value from it, etc.).
+functions for initialising an empty list, destroying a list,
+inserting into this list and removing values from it, etc.).
 Once you have spotted this coding pattern, it sounds reasonable to formalise it so that
 you don't always have to rewrite it by hand, each time.
-Indeed, this is the best way to involve : spot a pattern that people do mechanically,
-and automatise it.
+Indeed, this is the best way to evolve: spot a pattern that people do mechanically,
+and automate it.
 It worked in the automobile industry,
 and it also did for computer development.
-Automatization, from shell script... to new programming languages.
+Automation, from shell scripts... to new programming languages.
 
 ## Genesis of OOP
 
-This was the genese of the object paradigm.
-We call a such data type an object, add an
+This was the genesis of the object paradigm.
+We call such a data type an object, add an
 initialisation procedure always called at initialisation,
-and an other one always called when the resource become unreachable.
-Namely, OOP's constructor and destructors.
+and another one always called when the resource becomes unreachable.
+Namely, OOP's constructors and destructors.
 Because we always have lots of methods related to this object that
 always need as argument this object,
 we add them to the type definition and call them methods.
@@ -143,17 +143,17 @@ int Object::do_stuff(int input) {
 }
 ```
 
-This example is quite simple, and show how object paradigm is applied
+This example is quite simple, and shows how object paradigm is applied
 both in C and C++ languages.
 The second language is a lot more error-proof thanks to
 the support of the paradigm _in_ the language.
 
-Now you might interupt me and argue 'object paradim isn't just about methods glued to a type'.
+Now you might interrupt me and argue 'object paradigm isn't just about methods glued to a type'.
 And you would be right.
-I swept under the rug _inheritence_.
-This feature actually comes from spotting another codding patter C developers were also
+I swept under the rug _inheritance_.
+This feature actually comes from spotting another coding pattern C developers were also
 doing quite frequently.
-You reproduce the inheritence by agregating types, and using pointer arithmetic,
+You reproduce the inheritance by aggregating types, and using pointer arithmetic,
 as shown below.
 
 ```c
@@ -208,43 +208,43 @@ A* q = &obj_c;
 
 Introducing this feature in the language ensure automatic conversion from B* to A* with
 the right pointer arithmetic.
-It remove the risk of often hard to spot bugs.
-Inheriting doesn't apply only to type, it apply to methods.
-You can call methods working with a type A on instance of type B.
+It removes the risk of often hard to spot bugs.
+Inheriting doesn't apply only to types, it applies to methods.
+You can call methods working with a type A on instances of type B.
 This is the key reason of this pointer conversion.
 
-The languages C++ and Java alow something even stronguer than reusing methode
-for subtypes in inheritence hierarchy.
+The languages C++ and Java allow something even stronger than reusing methods
+for subtypes in inheritance hierarchy.
 Through abstract methods, or Java's interface,
 you can force the existence of methods on a given type.
 Such that the behavior can be different with different types,
-but the interface to work on them remind the same.
+but the interface to work on them remains the same.
 Allowing huge code factorisation and genericity of algorithms.
 
 ## So why is OOP wrong?
 
 Before saying anything,
-I want to show you how does object looks like in different mainstream languages.
+I want to show you how objects look like in different mainstream languages.
 
 ![Object Languages](data/object-languages.png)
 
 Of course, you can make schemes similar to java in C++ ;
-interface are obtained through abstract class.
+interfaces are obtained through abstract classes.
 It's just that the language doesn't prevent you from gluing too many things together
 (but that's actually part of the C++ philosophy : allow doing
-as much thing as you can imagine, but you have to make carefully your design decisions).
+as many things as you can imagine, but you have to make carefully your design decisions).
 
 Looking at the scheme, we see that always, in both languages,
 type definition and method definitions are glued together.
 You **can not** define a type and later,
 in a completely independent way, implement methods for this type.
 Actually, if C++ and Java are the only object languages you have heard about,
-my last sentence might sounds really strange for you (even maybe sounds like nonsense).
-But notice that in D, you **can** implement something rely similar to methods in a
+my last sentence might sound really strange to you (and maybe even sound like nonsense).
+But notice that in D, you **can** implement something really similar to methods in a
 complementary independent way of type definition.
 Why would you do that? Let me give you a tasty example.
 
-A guy (let call him A) make a colorful library describing tasty chocolate biscuits.
+A guy (let's call him A) makes a colorful library describing tasty chocolate biscuits.
 Here is a little bit of his library.
 
 ```
@@ -253,16 +253,16 @@ Biscuit -> Cookie -> FullChocolateCookie
         -> Oreo
 ```
 
-He think a lot about cooking such wonderful wonders, an implement many sophisticated methods.
+He thinks a lot about cooking such wonderful wonders, and implements many sophisticated methods.
 
 Now another guy (named B) just discovered the best way to eat biscuits,
 so that you can really enjoy all the taste and perfume they carry.
 Not only for chocolate biscuits, but for any biscuit in the world.
-He implements many new biscuit, and their _eat_ method.
+He implements many new biscuits, and their _eat_ method.
 But in those languages, his only way to add an _eat_ method to A's cookies is to either:
 
-- Re-implement all the biscuit A did in his library, or modify A's library to add his eat method,
-- Encapsulate the A library in some container, like a 'biscuit metal box', which is definitively not as easy to eat (especially because metal tends to be harder your teeth).
+- Re-implement all the biscuits A did in his library, or modify A's library to add his eat method,
+- Encapsulate the A library in some container, like a 'biscuit metal box', which is definitely not as easy to eat (especially because metal tends to be harder than your teeth).
 
 If you develop library and re-use existing libraries,
 that's a problem you probably already encountered many times.
@@ -270,7 +270,7 @@ that's a problem you probably already encountered many times.
 This is because there is actually no good reason to enforce (Java style)
 interface implementation where type definition occurs.
 This is the first big issue coming from the way object model
-is implemented **and** conceived in developer's mind.
+is implemented **and** conceived in developers' minds.
 
 The second big issue, related to the way OOP is done today,
 is the huge verbosity and boilerplate code introduced by encapsulation.
@@ -295,10 +295,10 @@ So much redundancy.
 Have a look at LLVM's example for heavily verbose C++ code
 (that is actually good C++ practice...).
 Each variable's name is written three times.
-I would say that this code is three times longer that it should be
-(I mean, if we was living in a perfect world).
+I would say that this code is three times longer than it should be
+(I mean, if we were living in a perfect world).
 But there isn't a better way to do it, conforming to usual understanding of OOP.
-If so, LLVM's developer would have found it and spreed the word.
+If so, LLVM's developer would have found it and spread the word.
 
 ## The categoric paradigm
 
@@ -313,12 +313,12 @@ A typeclass (it's a mathematical class) definition is similar to a java interfac
 Types that become instances of this typeclass should implement its methods, but
 the main difference is that the belonging of a type T to a given typeclass C can be
 stated independently of the typeclass definition and of the type definition.
-In rust, typeclass are named trait.
-Types are types (as they are in C) and the link between them, the instanciation of
-the trait of a type can be done independently of the definition of the trait and of
+In rust, typeclasses are named traits.
+Types are types (as they are in C) and the link between them, the instantiation of
+the trait for a type can be done independently of the definition of the trait and of
 the definition of the type.
 
-Here is bellow a short example from rust's documentation[^trait]:
+Here is below a short example from rust's documentation[^trait]:
 
 ```rust
 // # A Sheep object:
@@ -384,28 +384,28 @@ impl Animal for Sheep {
 }
 ```
 
-See how this three things can be done independently.
+See how these three things can be done independently.
 
-Similar things can be archived in haskell,
-though constructor and destructor doesn't exist.
-But Haskell's variable are by default immutable,
+Similar things can be achieved in Haskell,
+though constructors and destructors don't exist.
+But Haskell's variables are by default immutable,
 and the language is full of laziness.
-In a such context, looking for a constructor or a destructor doesn't make sens.
+In such a context, looking for a constructor or a destructor doesn't make sense.
 But for the curious, what is done in rust for methods can be done in the
 same way in Haskell.
 
 ## Conclusion
 
-Though this article have a really catchy title,
+Though this article has a really catchy title,
 the main point is to show you another perspective for the concept of object
 that is quite different from the one OOP's developer are used to.
 The first goal is to show the weakness of the object paradigm,
-and the second is to demonstrate how some of them can be strengthen
-from a small switch in the viewpoint, using emerging languages for examples.
-The view point demonstrated here is more known in the functional programming land
-(although not all functional programming languages offers such features).
-The Mozilla fondation made a wonderful work by creating rust, a language that provide
-both the functional and procedural paradigms, and also allow taking the
+and the second is to demonstrate how some of them can be strengthened
+from a small switch in the viewpoint, using emerging languages for example.
+The viewpoint demonstrated here is more known in the functional programming land
+(although not all functional programming languages offer such features).
+The Mozilla Foundation did wonderful work by creating Rust, a language that provides
+both the functional and procedural paradigms, and also allows taking the
 object approach in cases where it fits better than the two previous paradigms.
 I hope that it made you question yourself on the object oriented paradigm and
 developed your curiosity for other languages.
@@ -417,14 +417,14 @@ our usual tools from procedural languages. So don't turn your head away,
 just because your favorite language doesn't provide such features :)
 
 [^procedural-paradigm]: Procedural paradigm means essentially
-    that the language provide functions with side effects, and code is written linearly.
-    You can see it like an enhencement of languages that only provide goto and jumps.
+    that the language provides functions with side effects, and code is written linearly.
+    You can see it like an enhancement of languages that only provide goto and jumps.
 
 [^effective-cpp]: This is a really good book on good programming advices
-    for C++ developer. Despite the critic made in this article, it's definitively
+    for C++ developer. Despite the criticism made in this article, it's definitely
     a book full of good practices.
 
 [^trait]: See [rust traits](http://rustbyexample.com/trait.html)
 
-[^wrong]: Things aren't black and white. The object paradigm is definitively well suited
+[^wrong]: Things aren't black and white. The object paradigm is definitely well suited
     for many tasks like modeling GUI.


### PR DESCRIPTION
## Summary
- Exhaustive proofreading of all 22 blog posts (English and French)
- 524 lines changed — purely typo/grammar corrections, no content changes
- Fixes include: misspellings, subject-verb agreement, gender/number agreement (French), accent corrections, punctuation

## Changed files
All 22 posts in `_posts/` — from `gdt-and-idt` (2009) to `list-zipper-swift` (2019)

## Test plan
- [x] `bundle exec jekyll build` succeeds
- [x] Balanced diff (524 insertions, 524 deletions) — no content added/removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)